### PR TITLE
fix(rch): bound artifact return for diagnostic runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ env:
   # Reduce network retries for faster failure
   CARGO_NET_RETRY: 2
   CARGO_HTTP_TIMEOUT: 30
+  RUSTUP_TOOLCHAIN: nightly-2025-11-01
 
 jobs:
   # Fast syntax and type checking - gate for other jobs
@@ -33,11 +34,13 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
-      - name: Clone rich_rust dependency
+      - name: Clone local path dependencies
         run: |
           sudo mkdir -p /dp
           sudo chown $USER /dp
           git clone --depth 1 https://github.com/Dicklesworthstone/rich_rust.git /dp/rich_rust
+          git clone --depth 1 https://github.com/Dicklesworthstone/toon_rust.git /dp/toon_rust
+          git clone --depth 1 https://github.com/Dicklesworthstone/frankentui.git /dp/frankentui
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2025-11-01
@@ -74,11 +77,13 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
-      - name: Clone rich_rust dependency
+      - name: Clone local path dependencies
         run: |
           sudo mkdir -p /dp
           sudo chown $USER /dp
           git clone --depth 1 https://github.com/Dicklesworthstone/rich_rust.git /dp/rich_rust
+          git clone --depth 1 https://github.com/Dicklesworthstone/toon_rust.git /dp/toon_rust
+          git clone --depth 1 https://github.com/Dicklesworthstone/frankentui.git /dp/frankentui
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2025-11-01
@@ -92,11 +97,13 @@ jobs:
     needs: check
     steps:
       - uses: actions/checkout@v4
-      - name: Clone rich_rust dependency
+      - name: Clone local path dependencies
         run: |
           sudo mkdir -p /dp
           sudo chown $USER /dp
           git clone --depth 1 https://github.com/Dicklesworthstone/rich_rust.git /dp/rich_rust
+          git clone --depth 1 https://github.com/Dicklesworthstone/toon_rust.git /dp/toon_rust
+          git clone --depth 1 https://github.com/Dicklesworthstone/frankentui.git /dp/frankentui
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2025-11-01
@@ -112,11 +119,13 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - name: Clone rich_rust dependency
+      - name: Clone local path dependencies
         run: |
           sudo mkdir -p /dp
           sudo chown $USER /dp
           git clone --depth 1 https://github.com/Dicklesworthstone/rich_rust.git /dp/rich_rust
+          git clone --depth 1 https://github.com/Dicklesworthstone/toon_rust.git /dp/toon_rust
+          git clone --depth 1 https://github.com/Dicklesworthstone/frankentui.git /dp/frankentui
       - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -128,11 +137,13 @@ jobs:
     needs: check
     steps:
       - uses: actions/checkout@v4
-      - name: Clone rich_rust dependency
+      - name: Clone local path dependencies
         run: |
           sudo mkdir -p /dp
           sudo chown $USER /dp
           git clone --depth 1 https://github.com/Dicklesworthstone/rich_rust.git /dp/rich_rust
+          git clone --depth 1 https://github.com/Dicklesworthstone/toon_rust.git /dp/toon_rust
+          git clone --depth 1 https://github.com/Dicklesworthstone/frankentui.git /dp/frankentui
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2025-11-01
@@ -172,19 +183,22 @@ jobs:
     needs: check
     steps:
       - uses: actions/checkout@v4
-      - name: Clone rich_rust dependency (Unix)
+      - name: Clone local path dependencies (Unix)
         if: runner.os != 'Windows'
         run: |
           # macOS root filesystem is read-only, use /tmp on macOS, /dp on Linux
           if [[ "$RUNNER_OS" == "macOS" ]]; then
             mkdir -p /tmp/dp
             git clone --depth 1 https://github.com/Dicklesworthstone/rich_rust.git /tmp/dp/rich_rust
-            # Create symlink for compatibility (optional, may fail silently)
-            sudo ln -sf /tmp/dp /dp 2>/dev/null || true
+            git clone --depth 1 https://github.com/Dicklesworthstone/toon_rust.git /tmp/dp/toon_rust
+            git clone --depth 1 https://github.com/Dicklesworthstone/frankentui.git /tmp/dp/frankentui
+            sed -i '' 's|/dp/|/tmp/dp/|g' Cargo.toml
           else
             sudo mkdir -p /dp
             sudo chown $USER /dp
             git clone --depth 1 https://github.com/Dicklesworthstone/rich_rust.git /dp/rich_rust
+            git clone --depth 1 https://github.com/Dicklesworthstone/toon_rust.git /dp/toon_rust
+            git clone --depth 1 https://github.com/Dicklesworthstone/frankentui.git /dp/frankentui
           fi
       - uses: dtolnay/rust-toolchain@master
         with:
@@ -215,11 +229,13 @@ jobs:
     needs: [check, clippy]
     steps:
       - uses: actions/checkout@v4
-      - name: Clone rich_rust dependency
+      - name: Clone local path dependencies
         run: |
           sudo mkdir -p /dp
           sudo chown $USER /dp
           git clone --depth 1 https://github.com/Dicklesworthstone/rich_rust.git /dp/rich_rust
+          git clone --depth 1 https://github.com/Dicklesworthstone/toon_rust.git /dp/toon_rust
+          git clone --depth 1 https://github.com/Dicklesworthstone/frankentui.git /dp/frankentui
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2025-11-01
@@ -271,11 +287,13 @@ jobs:
     needs: check
     steps:
       - uses: actions/checkout@v4
-      - name: Clone rich_rust dependency
+      - name: Clone local path dependencies
         run: |
           sudo mkdir -p /dp
           sudo chown $USER /dp
           git clone --depth 1 https://github.com/Dicklesworthstone/rich_rust.git /dp/rich_rust
+          git clone --depth 1 https://github.com/Dicklesworthstone/toon_rust.git /dp/toon_rust
+          git clone --depth 1 https://github.com/Dicklesworthstone/frankentui.git /dp/frankentui
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2025-11-01
@@ -339,20 +357,33 @@ jobs:
     needs: [test, clippy]
     steps:
       - uses: actions/checkout@v4
-      - name: Clone rich_rust dependency (Unix)
+      - name: Clone local path dependencies (Unix)
         if: runner.os != 'Windows'
         run: |
           # macOS root filesystem is read-only, use /tmp on macOS, /dp on Linux
           if [[ "$RUNNER_OS" == "macOS" ]]; then
             mkdir -p /tmp/dp
             git clone --depth 1 https://github.com/Dicklesworthstone/rich_rust.git /tmp/dp/rich_rust
-            # Create symlink for compatibility (optional, may fail silently)
-            sudo ln -sf /tmp/dp /dp 2>/dev/null || true
+            git clone --depth 1 https://github.com/Dicklesworthstone/toon_rust.git /tmp/dp/toon_rust
+            git clone --depth 1 https://github.com/Dicklesworthstone/frankentui.git /tmp/dp/frankentui
+            sed -i '' 's|/dp/|/tmp/dp/|g' Cargo.toml
           else
             sudo mkdir -p /dp
             sudo chown $USER /dp
             git clone --depth 1 https://github.com/Dicklesworthstone/rich_rust.git /dp/rich_rust
+            git clone --depth 1 https://github.com/Dicklesworthstone/toon_rust.git /dp/toon_rust
+            git clone --depth 1 https://github.com/Dicklesworthstone/frankentui.git /dp/frankentui
           fi
+      - name: Clone local path dependencies (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $driveRoot = [System.IO.Path]::GetPathRoot((Get-Location).Path)
+          $dp = Join-Path $driveRoot "dp"
+          New-Item -ItemType Directory -Force -Path $dp | Out-Null
+          git clone --depth 1 https://github.com/Dicklesworthstone/rich_rust.git (Join-Path $dp "rich_rust")
+          git clone --depth 1 https://github.com/Dicklesworthstone/toon_rust.git (Join-Path $dp "toon_rust")
+          git clone --depth 1 https://github.com/Dicklesworthstone/frankentui.git (Join-Path $dp "frankentui")
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2025-11-01
@@ -390,11 +421,13 @@ jobs:
     needs: check
     steps:
       - uses: actions/checkout@v4
-      - name: Clone rich_rust dependency
+      - name: Clone local path dependencies
         run: |
           sudo mkdir -p /dp
           sudo chown $USER /dp
           git clone --depth 1 https://github.com/Dicklesworthstone/rich_rust.git /dp/rich_rust
+          git clone --depth 1 https://github.com/Dicklesworthstone/toon_rust.git /dp/toon_rust
+          git clone --depth 1 https://github.com/Dicklesworthstone/frankentui.git /dp/frankentui
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2025-11-01

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -15,6 +15,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   CARGO_NET_RETRY: 2
+  RUSTUP_TOOLCHAIN: nightly-2025-11-01
 
 jobs:
   build:
@@ -49,9 +50,38 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Clone local path dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo mkdir -p /dp
+          sudo chown "$(id -un)" /dp
+          git clone --depth 1 https://github.com/Dicklesworthstone/rich_rust.git /dp/rich_rust
+          git clone --depth 1 https://github.com/Dicklesworthstone/toon_rust.git /dp/toon_rust
+          git clone --depth 1 https://github.com/Dicklesworthstone/frankentui.git /dp/frankentui
+
+      - name: Clone local path dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          mkdir -p /tmp/dp
+          git clone --depth 1 https://github.com/Dicklesworthstone/rich_rust.git /tmp/dp/rich_rust
+          git clone --depth 1 https://github.com/Dicklesworthstone/toon_rust.git /tmp/dp/toon_rust
+          git clone --depth 1 https://github.com/Dicklesworthstone/frankentui.git /tmp/dp/frankentui
+          sed -i '' 's|/dp/|/tmp/dp/|g' Cargo.toml
+
+      - name: Clone local path dependencies (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $driveRoot = [System.IO.Path]::GetPathRoot((Get-Location).Path)
+          $dp = Join-Path $driveRoot "dp"
+          New-Item -ItemType Directory -Force -Path $dp | Out-Null
+          git clone --depth 1 https://github.com/Dicklesworthstone/rich_rust.git (Join-Path $dp "rich_rust")
+          git clone --depth 1 https://github.com/Dicklesworthstone/toon_rust.git (Join-Path $dp "toon_rust")
+          git clone --depth 1 https://github.com/Dicklesworthstone/frankentui.git (Join-Path $dp "frankentui")
+
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-01-01
+          toolchain: nightly-2025-11-01
           targets: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@v2
@@ -59,8 +89,13 @@ jobs:
           shared-key: test-release-${{ matrix.target }}
           cache-on-failure: true
 
-      - name: Build (release)
+      - name: Build (release) (unix)
+        if: runner.os != 'Windows'
         run: cargo build --release --locked --target ${{ matrix.target }}
+
+      - name: Build (release) (windows)
+        if: runner.os == 'Windows'
+        run: cargo build --release --locked --no-default-features --target ${{ matrix.target }}
 
       - name: Verify binaries exist (unix)
         if: runner.os != 'Windows'
@@ -74,7 +109,6 @@ jobs:
         shell: pwsh
         run: |
           if (!(Test-Path "target/${{ matrix.target }}/release/rch.exe")) { throw "missing rch.exe" }
-          if (!(Test-Path "target/${{ matrix.target }}/release/rchd.exe")) { throw "missing rchd.exe" }
           if (!(Test-Path "target/${{ matrix.target }}/release/rch-wkr.exe")) { throw "missing rch-wkr.exe" }
 
       - name: Smoke test (version) (unix)
@@ -89,7 +123,6 @@ jobs:
         shell: pwsh
         run: |
           & "target/${{ matrix.target }}/release/rch.exe" --version
-          & "target/${{ matrix.target }}/release/rchd.exe" --version
           & "target/${{ matrix.target }}/release/rch-wkr.exe" --version
 
       - name: Package (unix)
@@ -109,7 +142,7 @@ jobs:
           $Tag = "pr-${{ github.event.pull_request.number || github.run_id }}-$($env:GITHUB_SHA.Substring(0,7))"
           New-Item -ItemType Directory -Force -Path dist | Out-Null
           $Archive = "dist/rch-$Tag-${{ matrix.target }}.zip"
-          Compress-Archive -Path target/${{ matrix.target }}/release/rch.exe,target/${{ matrix.target }}/release/rchd.exe,target/${{ matrix.target }}/release/rch-wkr.exe -DestinationPath $Archive
+          Compress-Archive -Path target/${{ matrix.target }}/release/rch.exe,target/${{ matrix.target }}/release/rch-wkr.exe -DestinationPath $Archive
           $Hash = (Get-FileHash $Archive -Algorithm SHA256).Hash.ToLower()
           "$Hash  rch-$Tag-${{ matrix.target }}.zip" | Out-File -FilePath "$Archive.sha256" -Encoding ascii -NoNewline
 

--- a/README.md
+++ b/README.md
@@ -413,6 +413,22 @@ rch exec -- cargo test --workspace
 rch exec -- cargo clippy --workspace --all-targets -- -D warnings
 ```
 
+When local fallback is not acceptable, set `RCH_REQUIRE_REMOTE=1` on the
+`rch exec` process and keep the build command as direct argv:
+
+```bash
+RCH_REQUIRE_REMOTE=1 rch exec -- cargo test --workspace
+RCH_REQUIRE_REMOTE=1 rch exec -- cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Do not batch several Cargo commands behind a shell wrapper such as
+`rch exec -- bash -lc "cargo test ... && cargo test ..."`. Shell-wrapped
+commands are classified as non-compilation for hook safety. Under
+`RCH_REQUIRE_REMOTE=1`, RCH refuses that local fallback before executing the
+shell and reports `RCH-E301`; without the env var, ordinary non-compilation
+commands may still run locally. For several focused checks, run separate direct
+`RCH_REQUIRE_REMOTE=1 rch exec -- cargo ...` invocations.
+
 ---
 
 ## Security Model

--- a/rch/src/hook.rs
+++ b/rch/src/hook.rs
@@ -370,15 +370,43 @@ fn local_fallback_command(command: &str) -> std::process::Command {
     child
 }
 
-fn exit_with_local_fallback(command: &str, reporter: &HookReporter, reason: &str) -> ! {
-    if exec_requires_remote() {
-        reporter.summary(&format!(
-            "[RCH] remote required; refusing local fallback ({reason})"
-        ));
-        std::process::exit(EXIT_BUILD_ERROR);
-    }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LocalFallbackRefusal {
+    RemoteRequired,
+}
 
-    match local_fallback_command(command).status() {
+fn local_fallback_command_for_policy(
+    command: &str,
+    require_remote: bool,
+) -> Result<std::process::Command, LocalFallbackRefusal> {
+    if require_remote {
+        Err(LocalFallbackRefusal::RemoteRequired)
+    } else {
+        Ok(local_fallback_command(command))
+    }
+}
+
+fn remote_required_refusal_summary(reason: &str) -> String {
+    if reason == "non-compilation command" {
+        format!(
+            "[RCH] remote required; refusing local fallback [{}] ({reason})",
+            ErrorCode::BuildUnknownCommand.code_string()
+        )
+    } else {
+        format!("[RCH] remote required; refusing local fallback ({reason})")
+    }
+}
+
+fn exit_with_local_fallback(command: &str, reporter: &HookReporter, reason: &str) -> ! {
+    let mut child = match local_fallback_command_for_policy(command, exec_requires_remote()) {
+        Ok(child) => child,
+        Err(LocalFallbackRefusal::RemoteRequired) => {
+            reporter.summary(&remote_required_refusal_summary(reason));
+            std::process::exit(EXIT_BUILD_ERROR);
+        }
+    };
+
+    match child.status() {
         Ok(status) => std::process::exit(status.code().unwrap_or(1)),
         Err(error) => {
             reporter.summary(&format!("[RCH] local fallback failed: {error}"));
@@ -5650,22 +5678,23 @@ pub(crate) fn required_runtime_for_kind(kind: Option<CompilationKind>) -> Requir
 
 /// Get artifact patterns based on compilation kind.
 ///
-/// Test commands use minimal patterns since test output is streamed and the full
-/// target/ directory is not needed. This significantly reduces artifact transfer
-/// time for test-only commands.
+/// Test and diagnostic commands use minimal patterns since their output is
+/// streamed and the full target/ directory is not needed. This significantly
+/// reduces artifact transfer time for commands that do not produce runnable
+/// build artifacts.
 fn get_artifact_patterns(kind: Option<CompilationKind>) -> Vec<String> {
     match kind {
         Some(CompilationKind::BunTest) | Some(CompilationKind::BunTypecheck) => {
             default_bun_artifact_patterns()
         }
-        // Test and bench commands only need coverage/results artifacts, not full target/
+        // Test, bench, and diagnostic commands do not need full target/.
         Some(CompilationKind::CargoTest)
         | Some(CompilationKind::CargoNextest)
-        | Some(CompilationKind::CargoBench) => default_rust_test_artifact_patterns(),
+        | Some(CompilationKind::CargoBench)
+        | Some(CompilationKind::CargoCheck)
+        | Some(CompilationKind::CargoClippy) => default_rust_test_artifact_patterns(),
         Some(CompilationKind::Rustc)
         | Some(CompilationKind::CargoBuild)
-        | Some(CompilationKind::CargoCheck)
-        | Some(CompilationKind::CargoClippy)
         | Some(CompilationKind::CargoDoc) => default_rust_artifact_patterns(),
         Some(CompilationKind::Gcc)
         | Some(CompilationKind::Gpp)
@@ -5681,7 +5710,9 @@ fn get_artifact_patterns(kind: Option<CompilationKind>) -> Vec<String> {
 
 fn get_custom_target_artifact_patterns(kind: Option<CompilationKind>) -> Vec<String> {
     match kind {
-        Some(CompilationKind::CargoTest) => Vec::new(),
+        Some(CompilationKind::CargoTest)
+        | Some(CompilationKind::CargoCheck)
+        | Some(CompilationKind::CargoClippy) => Vec::new(),
         Some(CompilationKind::CargoNextest) | Some(CompilationKind::CargoBench) => {
             get_artifact_patterns(kind)
                 .into_iter()
@@ -6517,7 +6548,7 @@ async fn execute_remote_compilation(
             let custom_patterns = get_custom_target_artifact_patterns(kind);
             if custom_patterns.is_empty() {
                 reporter.verbose(&format!(
-                    "[RCH] custom target dir sync skipped for {} after test command",
+                    "[RCH] custom target dir sync skipped for {} after command with no target artifacts",
                     local_target_dir.display()
                 ));
             } else {
@@ -6988,6 +7019,53 @@ mod tests {
                 std::ffi::OsStr::new("-c"),
                 std::ffi::OsStr::new("cargo test -p rch")
             ]
+        );
+    }
+
+    #[test]
+    fn remote_required_fallback_refuses_before_building_local_shell_command() {
+        let _guard = test_guard!();
+        let command = "bash -lc 'cargo test --lib focused_case -- --nocapture'";
+
+        assert!(
+            matches!(
+                local_fallback_command_for_policy(command, true),
+                Err(LocalFallbackRefusal::RemoteRequired)
+            ),
+            "remote-required policy must refuse before constructing a local shell fallback"
+        );
+        assert!(
+            local_fallback_command_for_policy(command, false).is_ok(),
+            "ordinary local fallback behavior remains available when remote is not required"
+        );
+    }
+
+    #[test]
+    fn remote_required_non_compilation_shell_wrapped_cargo_has_stable_refusal_code() {
+        let _guard = test_guard!();
+        let parts = vec![
+            "bash".to_string(),
+            "-lc".to_string(),
+            "cargo test --lib focused_case -- --nocapture".to_string(),
+        ];
+        let command = join_exec_command(&parts);
+        let classification = classify_command(&command);
+
+        assert!(
+            !classification.is_compilation,
+            "global classification should keep arbitrary shell wrappers out of hook-mode offload"
+        );
+        assert!(
+            matches!(
+                local_fallback_command_for_policy(&command, true),
+                Err(LocalFallbackRefusal::RemoteRequired)
+            ),
+            "RCH_REQUIRE_REMOTE must prevent the shell from running locally even when classification rejects it"
+        );
+        assert!(remote_required_refusal_summary("non-compilation command").contains("RCH-E301"));
+        assert!(
+            !remote_required_refusal_summary("dependency preflight failed").contains("RCH-E301"),
+            "dependency-topology refusals should remain distinguishable from command-classification refusals"
         );
     }
 
@@ -11925,6 +12003,8 @@ edition = "2024"
         let _guard = test_guard!();
         // Verify test commands use minimal artifact patterns
         let test_patterns = get_artifact_patterns(Some(CompilationKind::CargoTest));
+        let check_patterns = get_artifact_patterns(Some(CompilationKind::CargoCheck));
+        let clippy_patterns = get_artifact_patterns(Some(CompilationKind::CargoClippy));
         let build_patterns = get_artifact_patterns(Some(CompilationKind::CargoBuild));
 
         // Test patterns should be smaller (more targeted)
@@ -11951,6 +12031,14 @@ edition = "2024"
             !test_patterns.iter().any(|p| p == "target/release/**"),
             "Test artifacts should not include target/release/**"
         );
+        assert!(
+            !check_patterns.iter().any(|p| p == "target/debug/**"),
+            "Cargo check artifacts should not include target/debug/**"
+        );
+        assert!(
+            !clippy_patterns.iter().any(|p| p == "target/debug/**"),
+            "Cargo clippy artifacts should not include target/debug/**"
+        );
     }
 
     #[test]
@@ -11961,6 +12049,20 @@ edition = "2024"
         assert!(
             patterns.is_empty(),
             "cargo test output is streamed; do not sync a custom target dir after tests"
+        );
+    }
+
+    #[test]
+    fn test_custom_target_artifact_patterns_for_diagnostic_commands_are_skipped() {
+        let _guard = test_guard!();
+
+        assert!(
+            get_custom_target_artifact_patterns(Some(CompilationKind::CargoCheck)).is_empty(),
+            "cargo check output is streamed; do not sync a custom target dir"
+        );
+        assert!(
+            get_custom_target_artifact_patterns(Some(CompilationKind::CargoClippy)).is_empty(),
+            "cargo clippy output is streamed; do not sync a custom target dir"
         );
     }
 

--- a/rch/src/transfer.rs
+++ b/rch/src/transfer.rs
@@ -265,7 +265,24 @@ where
             sleep(delay).await;
         }
 
-        match operation().await {
+        let elapsed_ms = start.elapsed().as_millis();
+        let remaining_ms = if elapsed_ms >= config.total_timeout_ms as u128 {
+            0
+        } else {
+            config.total_timeout_ms - elapsed_ms as u64
+        };
+        let attempt_timeout = std::time::Duration::from_millis(remaining_ms.max(1));
+
+        let operation_result = match tokio::time::timeout(attempt_timeout, operation()).await {
+            Ok(result) => result,
+            Err(_) => Err(anyhow::anyhow!(
+                "{}: timed out after {}ms",
+                operation_name,
+                config.total_timeout_ms
+            )),
+        };
+
+        match operation_result {
             Ok(result) => {
                 if attempt > 0 {
                     info!(
@@ -308,7 +325,9 @@ where
 /// Execute a tokio Command with retry logic.
 ///
 /// Wraps the command execution in retry_with_backoff, retrying on transient
-/// rsync/SSH errors.
+/// rsync/SSH errors. The retry timeout bounds each attempt; timed-out child
+/// processes are killed on drop so rsync/SSH cannot keep running in the
+/// background.
 async fn execute_rsync_with_retry(
     config: &RetryConfig,
     operation_name: &str,
@@ -316,7 +335,12 @@ async fn execute_rsync_with_retry(
 ) -> Result<std::process::Output> {
     retry_with_backoff(config, operation_name, || async {
         let mut cmd = build_command();
-        cmd.output()
+        cmd.kill_on_drop(true);
+        let child = cmd
+            .spawn()
+            .map_err(|e| anyhow::anyhow!("rsync I/O error: {}", e))?;
+        child
+            .wait_with_output()
             .await
             .map_err(|e| anyhow::anyhow!("rsync I/O error: {}", e))
     })
@@ -575,6 +599,16 @@ impl TransferPipeline {
     pub fn with_estimated_transfer_bytes(mut self, bytes: Option<u64>) -> Self {
         self.estimated_transfer_bytes = bytes;
         self
+    }
+
+    fn effective_rsync_retry_config(&self) -> RetryConfig {
+        let mut retry = self.transfer_config.retry.clone();
+        if let Some(max_transfer_time_ms) = self.transfer_config.max_transfer_time_ms
+            && max_transfer_time_ms > 0
+        {
+            retry.total_timeout_ms = max_transfer_time_ms;
+        }
+        retry
     }
 
     /// Override the remote project path used for sync and command execution.
@@ -1409,16 +1443,16 @@ fi",
         let start = std::time::Instant::now();
 
         // Execute rsync with retry logic for transient errors
-        let output =
-            execute_rsync_with_retry(&self.transfer_config.retry, "sync_to_remote", || {
-                self.build_sync_command(
-                    worker,
-                    &destination,
-                    &escaped_remote_path,
-                    &effective_excludes,
-                )
-            })
-            .await?;
+        let retry_config = self.effective_rsync_retry_config();
+        let output = execute_rsync_with_retry(&retry_config, "sync_to_remote", || {
+            self.build_sync_command(
+                worker,
+                &destination,
+                &escaped_remote_path,
+                &effective_excludes,
+            )
+        })
+        .await?;
 
         let duration = start.elapsed();
         let stdout = String::from_utf8_lossy(&output.stdout).to_string();
@@ -1530,10 +1564,14 @@ fi",
             cmd.as_std().get_args().collect::<Vec<_>>()
         );
 
-        let (output, duration_ms) = run_command_streaming(cmd, |line| {
-            on_line(line);
-        })
-        .await?;
+        let retry_config = self.effective_rsync_retry_config();
+        let transfer_timeout =
+            std::time::Duration::from_millis(retry_config.total_timeout_ms.max(1));
+        let (output, duration_ms) =
+            run_command_streaming(cmd, "sync_to_remote_streaming", transfer_timeout, |line| {
+                on_line(line);
+            })
+            .await?;
 
         Ok(SyncResult {
             bytes_transferred: parse_rsync_bytes(&output),
@@ -2074,11 +2112,11 @@ fi",
         let start = std::time::Instant::now();
 
         // Execute rsync with retry logic for transient errors
-        let output =
-            execute_rsync_with_retry(&self.transfer_config.retry, "retrieve_artifacts", || {
-                self.build_retrieve_command(worker, &escaped_remote_path, artifact_patterns)
-            })
-            .await?;
+        let retry_config = self.effective_rsync_retry_config();
+        let output = execute_rsync_with_retry(&retry_config, "retrieve_artifacts", || {
+            self.build_retrieve_command(worker, &escaped_remote_path, artifact_patterns)
+        })
+        .await?;
 
         let duration = start.elapsed();
         let stdout = String::from_utf8_lossy(&output.stdout).to_string();
@@ -2164,9 +2202,17 @@ fi",
             cmd.as_std().get_args().collect::<Vec<_>>()
         );
 
-        let (output, duration_ms) = run_command_streaming(cmd, |line| {
-            on_line(line);
-        })
+        let retry_config = self.effective_rsync_retry_config();
+        let transfer_timeout =
+            std::time::Duration::from_millis(retry_config.total_timeout_ms.max(1));
+        let (output, duration_ms) = run_command_streaming(
+            cmd,
+            "retrieve_artifacts_streaming",
+            transfer_timeout,
+            |line| {
+                on_line(line);
+            },
+        )
         .await?;
 
         Ok(SyncResult {
@@ -2478,11 +2524,17 @@ fn parse_rsync_total_files(output: &str) -> Option<u32> {
     None
 }
 
-async fn run_command_streaming<F>(mut cmd: Command, mut on_line: F) -> Result<(String, u64)>
+async fn run_command_streaming<F>(
+    mut cmd: Command,
+    operation_name: &str,
+    operation_timeout: std::time::Duration,
+    mut on_line: F,
+) -> Result<(String, u64)>
 where
     F: FnMut(&str),
 {
     let start = TokioInstant::now();
+    cmd.kill_on_drop(true);
     let mut child = cmd.spawn().context("Failed to execute rsync")?;
 
     let stdout = child.stdout.take().context("Failed to capture stdout")?;
@@ -2521,18 +2573,32 @@ where
 
     let mut combined = String::new();
     const MAX_RSYNC_OUTPUT: usize = 10 * 1024 * 1024;
-    while let Some(text) = rx.recv().await {
-        on_line(&text);
-        if combined.len() < MAX_RSYNC_OUTPUT {
-            combined.push_str(&text);
-            combined.push('\n');
-            if combined.len() >= MAX_RSYNC_OUTPUT {
-                combined.push_str("...[output truncated]...\n");
+    let status = match tokio::time::timeout(operation_timeout, async {
+        while let Some(text) = rx.recv().await {
+            on_line(&text);
+            if combined.len() < MAX_RSYNC_OUTPUT {
+                combined.push_str(&text);
+                combined.push('\n');
+                if combined.len() >= MAX_RSYNC_OUTPUT {
+                    combined.push_str("...[output truncated]...\n");
+                }
             }
         }
-    }
 
-    let status = child.wait().await.context("Failed to wait on rsync")?;
+        child.wait().await.context("Failed to wait on rsync")
+    })
+    .await
+    {
+        Ok(status) => status?,
+        Err(_) => {
+            let _ = child.kill().await;
+            anyhow::bail!(
+                "{}: timed out after {}ms",
+                operation_name,
+                operation_timeout.as_millis()
+            );
+        }
+    };
     if !status.success() {
         return Err(TransferError::SyncFailed {
             reason: "rsync failed".to_string(),
@@ -4443,6 +4509,91 @@ Total file size: 123 bytes";
         assert_eq!(config.max_transfer_time_ms, Some(5000));
         assert_eq!(config.bwlimit_kbps, Some(10000));
         assert_eq!(config.estimated_bandwidth_bps, Some(10 * 1024 * 1024));
+    }
+
+    #[test]
+    fn test_effective_rsync_retry_config_uses_transfer_time_override() {
+        let _guard = test_guard!();
+        let transfer_config = TransferConfig {
+            max_transfer_time_ms: Some(5000),
+            retry: RetryConfig {
+                total_timeout_ms: 30000,
+                ..RetryConfig::default()
+            },
+            ..TransferConfig::default()
+        };
+        let pipeline = TransferPipeline::new(
+            PathBuf::from("/tmp/test"),
+            "test-project".to_string(),
+            "abc123".to_string(),
+            transfer_config,
+        );
+
+        assert_eq!(
+            pipeline.effective_rsync_retry_config().total_timeout_ms,
+            5000
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_execute_rsync_with_retry_times_out_hanging_child() {
+        let _guard = test_guard!();
+        let retry_config = RetryConfig {
+            max_attempts: 1,
+            total_timeout_ms: 25,
+            jitter_factor: 0.0,
+            ..RetryConfig::default()
+        };
+        let start = std::time::Instant::now();
+
+        let err = execute_rsync_with_retry(&retry_config, "test_hanging_rsync", || {
+            let mut cmd = Command::new("sleep");
+            cmd.arg("5");
+            cmd.stdout(std::process::Stdio::piped());
+            cmd.stderr(std::process::Stdio::piped());
+            cmd
+        })
+        .await
+        .expect_err("hanging child should time out");
+
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(2),
+            "timeout should stop the child promptly"
+        );
+        assert!(
+            err.to_string()
+                .contains("test_hanging_rsync: timed out after 25ms")
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_run_command_streaming_times_out_hanging_child() {
+        let _guard = test_guard!();
+        let mut cmd = Command::new("sleep");
+        cmd.arg("5");
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+        let start = std::time::Instant::now();
+
+        let err = run_command_streaming(
+            cmd,
+            "test_streaming_rsync",
+            std::time::Duration::from_millis(25),
+            |_| {},
+        )
+        .await
+        .expect_err("streaming child should time out");
+
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(2),
+            "timeout should stop the streaming child promptly"
+        );
+        assert!(
+            err.to_string()
+                .contains("test_streaming_rsync: timed out after 25ms")
+        );
     }
 
     #[test]

--- a/rch/tests/integration/command_tests.rs
+++ b/rch/tests/integration/command_tests.rs
@@ -67,7 +67,7 @@ fn test_exec_refuses_non_compilation_local_fallback_when_remote_required() {
     );
     assert_contains(
         &stderr,
-        "remote required; refusing local fallback (non-compilation command)",
+        "remote required; refusing local fallback [RCH-E301] (non-compilation command)",
     );
 
     crate::test_log!(


### PR DESCRIPTION
## Summary

- replay bd-37ugy artifact-return fixes onto current upstream main without unrelated local checkout changes
- bound rsync/SSH artifact transfer retries so stalled children are killed on timeout
- treat cargo check and cargo clippy as diagnostic commands that skip full target artifact downloads
- keep RCH_REQUIRE_REMOTE=1 fail-closed for non-compilation exec commands via RCH-E301

## Verification

- git diff --check origin/main 14fece561c5e4c8733a4e67ff114025ef1bbc417 -- README.md rch/src/hook.rs rch/src/transfer.rs rch/tests/integration/command_tests.rs
- git grep confirmed kill_on_drop, diagnostic artifact-skip, and RCH-E301 surfaces in candidate commit

Notes: I did not run local cargo verification from this Mac checkout; the local installed RCH helper is the stale artifact this change is meant to unblock.