### PR TITLE
fix(scheduler): self-healing circuit window + first-class worker priority

### DIFF
--- a/rch-common/src/types.rs
+++ b/rch-common/src/types.rs
@@ -394,7 +394,13 @@ fn default_weight_network() -> f64 {
     0.1
 }
 fn default_weight_priority() -> f64 {
-    0.1
+    // Worker priority is a first-class selection factor: operators set high
+    // priority on preferred boxes (e.g. fast dedicated workers) and expect them
+    // to actually receive work. At the old 0.1 a top-priority worker gained at
+    // most +0.1 to its balanced score — too weak to overcome a warm-cache or
+    // lower-latency competitor, so the highest-priority workers could sit idle
+    // indefinitely. Load/slots still throttle a high-priority worker as it fills.
+    0.5
 }
 fn default_half_open_penalty() -> f64 {
     0.5
@@ -1654,12 +1660,20 @@ impl CircuitStats {
     }
 
     /// Get the error rate in the current window (0.0-1.0).
+    ///
+    /// Computed over the bounded recent-results window (the last
+    /// `CIRCUIT_HISTORY_SIZE` health checks) rather than the unbounded lifetime
+    /// `window_successes`/`window_failures` counters. A long-lived daemon polling
+    /// distant workers accumulates occasional transient failures over days; with a
+    /// lifetime ratio a currently-healthy worker could stay gated (circuit kept
+    /// open, depressed health score) until the daemon was restarted. A recency
+    /// window lets the rate self-heal as fresh successes age out old failures.
     pub fn error_rate(&self) -> f64 {
-        let total = self.window_successes + self.window_failures;
-        if total == 0 {
+        if self.recent_results.is_empty() {
             return 0.0;
         }
-        self.window_failures as f64 / total as f64
+        let failures = self.recent_results.iter().filter(|&&ok| !ok).count();
+        failures as f64 / self.recent_results.len() as f64
     }
 
     /// Record a successful operation.
@@ -1711,9 +1725,10 @@ impl CircuitStats {
             return true;
         }
 
-        // Open if error rate exceeds threshold (with minimum 5 samples)
-        let total = self.window_successes + self.window_failures;
-        if total >= 5 && self.error_rate() >= config.error_rate_threshold {
+        // Open if error rate exceeds threshold (with a minimum sample size).
+        // Counts samples in the bounded recent-results window so the gate
+        // reflects recent behavior, matching error_rate() above.
+        if self.recent_results.len() >= 5 && self.error_rate() >= config.error_rate_threshold {
             return true;
         }
 
@@ -1802,18 +1817,26 @@ impl CircuitStats {
             self.consecutive_failures = 0;
             self.consecutive_successes = 0;
             self.active_probes = 0;
-            // Reset the window on close
+            // Reset the window on close, INCLUDING the recent-results history
+            // that error_rate() now reads. Otherwise a freshly-recovered circuit
+            // would still compute a high error rate from the pre-failure samples
+            // and immediately re-open (flapping). Matches the original intent of
+            // resetting the error-rate inputs when the circuit recovers.
             self.window_successes = 0;
             self.window_failures = 0;
+            self.recent_results.clear();
         }
     }
 
     /// Reset the rolling window counters.
     ///
     /// Called periodically to ensure the window reflects recent activity.
+    /// Also clears the recent-results history that `error_rate()` is computed
+    /// from, so a reset truly zeroes the observed error rate.
     pub fn reset_window(&mut self) {
         self.window_successes = 0;
         self.window_failures = 0;
+        self.recent_results.clear();
     }
 
     /// Get recent health check results for history visualization.
@@ -3758,6 +3781,32 @@ retry_max = 2
 
         stats.record_failure(); // 5 samples: 2 success, 3 failures = 60% error rate
         assert!(stats.should_open(&config));
+    }
+
+    #[test]
+    fn test_circuit_close_clears_recent_results_no_flap() {
+        let _guard = test_guard!();
+        // Regression: error_rate() is computed over recent_results, so close()
+        // must clear that history or a recovered circuit immediately re-opens
+        // on stale pre-failure samples (flapping).
+        let mut stats = CircuitStats::new();
+        let config = CircuitBreakerConfig {
+            error_rate_threshold: 0.5,
+            ..Default::default()
+        };
+        for _ in 0..6 {
+            stats.record_failure();
+        }
+        assert!(stats.should_open(&config));
+        stats.open();
+        // Recover via half-open probes, then close.
+        stats.half_open();
+        stats.record_success();
+        stats.record_success();
+        stats.close();
+        // Error rate must be reset and the circuit must NOT immediately re-open.
+        assert_eq!(stats.error_rate(), 0.0);
+        assert!(!stats.should_open(&config));
     }
 
     #[test]

--- a/rchd/src/selection.rs
+++ b/rchd/src/selection.rs
@@ -985,15 +985,37 @@ impl WorkerSelector {
             return None;
         }
 
-        // Find the pinned worker in the eligible list
+        // Find the pinned worker in the eligible list.
+        let mut pinned: Option<(Arc<WorkerState>, CircuitState, u32)> = None;
         for (worker, circuit_state) in eligible {
             let config = worker.config.read().await;
             if config.id.as_str() == pinned_worker_id {
-                return Some((worker.clone(), *circuit_state));
+                pinned = Some((worker.clone(), *circuit_state, config.priority));
+                break;
+            }
+        }
+        let (worker, circuit_state, pinned_priority) = pinned?;
+
+        // Priority-aware pin skip: if a strictly higher-priority worker is
+        // eligible and has capacity for this job, skip the cache pin so the
+        // higher-priority worker can win normal scoring. This keeps deliberately
+        // preferred (high-priority) workers from being starved by affinity, while
+        // still preserving cache affinity once those workers are saturated (the
+        // skip condition no longer holds, so the pin is honored).
+        for (candidate, _) in eligible {
+            let config = candidate.config.read().await;
+            if config.priority > pinned_priority
+                && candidate.available_slots().await >= request.estimated_cores
+            {
+                debug!(
+                    "Skipping affinity pin {} for project {}: higher-priority worker {} (priority {}) has capacity",
+                    pinned_worker_id, request.project, config.id, config.priority
+                );
+                return None;
             }
         }
 
-        None
+        Some((worker, circuit_state))
     }
 
     /// Try to find a fallback worker when no eligible workers exist.


### PR DESCRIPTION
## Why

A fleet audit surfaced two scheduler issues:

1. **Healthy workers silently dropped from the dispatch pool on long-uptime daemons** → "not enough free build slots" even though workers were idle and reachable. On daemons up ~106h, `rch status` showed e.g. *5/12 healthy, 36/84 slots*; a `rch daemon restart` instantly restored *12/12, 84/84*. The workers were fine the whole time (probe OK).
2. **The highest-priority workers sat permanently idle.** Two workers configured `priority=110` (highest in the fleet) never received work while `priority=80` workers saturated to 8/8.

## Root causes (code-verified)

- **Circuit error rate was lifetime, not recent.** `CircuitStats::error_rate()` used the unbounded `window_successes`/`window_failures` counters (reset only on `close()`/never-called `reset_window()`). Over days, occasional transient probe failures skewed the ratio enough to keep a *currently-healthy* worker's circuit open / health score depressed, dropping it from `healthy_workers()` and zeroing its assignable slots until daemon restart.
- **Worker priority was a negligible tiebreaker.** In the default `Balanced` strategy, `priority` was pool-normalized then weighted at **0.1** (max +0.1 to score) — too weak to overcome a warm-cache or lower-latency competitor. Compounded by 60-min cache-affinity pinning that hard-overrides scoring, the highest-priority workers could never break in.

## Changes

**`rch-common/src/types.rs`**
- `CircuitStats::error_rate()` now computes over the bounded `recent_results` window (last `CIRCUIT_HISTORY_SIZE` health checks) instead of lifetime counters — self-heals as fresh successes age out old failures. `should_open()` sample-gate and `reset_window()` updated to match (reset now also clears `recent_results`). This also makes `health_score = 1 - error_rate` recency-based.
- `default_weight_priority` 0.1 → 0.5: worker priority becomes a first-class selection factor; load/slots still throttle a high-priority worker as it fills.

**`rchd/src/selection.rs`**
- `try_pinned_worker()` priority-aware skip: if a strictly higher-priority worker is eligible *with capacity*, the cache-affinity pin is skipped so it can win normal scoring; once higher-priority workers saturate, the pin is honored and cache affinity is preserved.

## Tests
- `rch-common`: 2037 pass (the one failure on macOS is a pre-existing `/private/var` symlink-canonicalization test, unrelated).
- `rchd`: 1327 pass, 0 fail — incl. all selection/affinity/priority/balanced tests.

## Notes
- Includes a `1.0.41 → 1.0.42` workspace version bump for release-readiness; drop/adjust if this rides a different release.
- A third audit finding — the benchmark scheduler computes a SpeedScore then discards it (`set_speed_score` never called fleet-wide, so SpeedScore is a uniform 50.0 no-op) — is intentionally **not** in this PR; a half-fix would cause benchmark spam. Recommend a focused follow-up to wire benchmark results into `set_speed_score` + persistence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)