### PR TITLE
ci: bump pinned nightly 2025-11-01 → 2026-06-06 (fix ftui-widgets isolate_lowest_one E0658)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ env:
   # Reduce network retries for faster failure
   CARGO_NET_RETRY: 2
   CARGO_HTTP_TIMEOUT: 30
-  RUSTUP_TOOLCHAIN: nightly-2025-11-01
+  RUSTUP_TOOLCHAIN: nightly-2026-06-06
 
 jobs:
   # Fast syntax and type checking - gate for other jobs
@@ -43,7 +43,7 @@ jobs:
           git clone --depth 1 https://github.com/Dicklesworthstone/frankentui.git /dp/frankentui
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-11-01
+          toolchain: nightly-2026-06-06
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -94,7 +94,7 @@ jobs:
           git clone --depth 1 https://github.com/Dicklesworthstone/frankentui.git /dp/frankentui
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-11-01
+          toolchain: nightly-2026-06-06
           components: rustfmt
       - run: cargo fmt --all -- --check
 
@@ -114,7 +114,7 @@ jobs:
           git clone --depth 1 https://github.com/Dicklesworthstone/frankentui.git /dp/frankentui
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-11-01
+          toolchain: nightly-2026-06-06
           components: clippy
       - uses: Swatinem/rust-cache@v2
         with:
@@ -154,7 +154,7 @@ jobs:
           git clone --depth 1 https://github.com/Dicklesworthstone/frankentui.git /dp/frankentui
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-11-01
+          toolchain: nightly-2026-06-06
       - uses: Swatinem/rust-cache@v2
       - name: Build documentation
         env:
@@ -210,7 +210,7 @@ jobs:
           fi
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-11-01
+          toolchain: nightly-2026-06-06
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: test-${{ matrix.name }}
@@ -246,7 +246,7 @@ jobs:
           git clone --depth 1 https://github.com/Dicklesworthstone/frankentui.git /dp/frankentui
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-11-01
+          toolchain: nightly-2026-06-06
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -304,7 +304,7 @@ jobs:
           git clone --depth 1 https://github.com/Dicklesworthstone/frankentui.git /dp/frankentui
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-11-01
+          toolchain: nightly-2026-06-06
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: benchmark
@@ -396,7 +396,7 @@ jobs:
           git clone --depth 1 https://github.com/Dicklesworthstone/frankentui.git (Join-Path $dp "frankentui")
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-11-01
+          toolchain: nightly-2026-06-06
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
         with:
@@ -440,7 +440,7 @@ jobs:
           git clone --depth 1 https://github.com/Dicklesworthstone/frankentui.git /dp/frankentui
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-11-01
+          toolchain: nightly-2026-06-06
           components: llvm-tools-preview
       - uses: taiki-e/install-action@cargo-llvm-cov
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,7 +52,7 @@ jobs:
           git clone --depth 1 https://github.com/Dicklesworthstone/frankentui.git /dp/frankentui
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-11-01
+          toolchain: nightly-2026-06-06
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,13 +35,13 @@ env:
   # Reduce network retries for faster failure
   CARGO_NET_RETRY: 2
   # Pin the toolchain at the env level so that *every* `cargo` invocation in
-  # this workflow uses nightly-2025-11-01 — the version dtolnay/rust-toolchain
+  # this workflow uses nightly-2026-06-06 — the version dtolnay/rust-toolchain
   # installs (with the per-job `targets:`) below. Without this, the in-repo
   # rust-toolchain.toml (channel = "nightly") would redirect cargo to the
   # *latest* nightly, which doesn't have the per-target stdlib installed → all
   # release jobs fail with `can't find crate for \`core\``. RUSTUP_TOOLCHAIN
   # takes precedence over both rust-toolchain.toml and `rustup override`.
-  RUSTUP_TOOLCHAIN: nightly-2025-11-01
+  RUSTUP_TOOLCHAIN: nightly-2026-06-06
 
 jobs:
   # Validate tag and plan the release
@@ -89,7 +89,7 @@ jobs:
           git clone --depth 1 https://github.com/Dicklesworthstone/frankentui.git /dp/frankentui
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-11-01
+          toolchain: nightly-2026-06-06
           targets: x86_64-unknown-linux-gnu
       - uses: Swatinem/rust-cache@v2
         with:
@@ -126,7 +126,7 @@ jobs:
           git clone --depth 1 https://github.com/Dicklesworthstone/frankentui.git /dp/frankentui
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-11-01
+          toolchain: nightly-2026-06-06
           targets: x86_64-unknown-linux-musl
       - name: Install musl-tools
         run: sudo apt-get update && sudo apt-get install -y musl-tools
@@ -165,7 +165,7 @@ jobs:
           git clone --depth 1 https://github.com/Dicklesworthstone/frankentui.git /dp/frankentui
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-11-01
+          toolchain: nightly-2026-06-06
           targets: aarch64-unknown-linux-gnu
       - uses: Swatinem/rust-cache@v2
         with:
@@ -204,7 +204,7 @@ jobs:
           sed -i '' 's|/dp/|/tmp/dp/|g' Cargo.toml
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-11-01
+          toolchain: nightly-2026-06-06
           targets: x86_64-apple-darwin
       - uses: Swatinem/rust-cache@v2
         with:
@@ -245,7 +245,7 @@ jobs:
           sed -i '' 's|/dp/|/tmp/dp/|g' Cargo.toml
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-11-01
+          toolchain: nightly-2026-06-06
           targets: aarch64-apple-darwin
       - uses: Swatinem/rust-cache@v2
         with:
@@ -283,7 +283,7 @@ jobs:
           git clone --depth 1 https://github.com/Dicklesworthstone/frankentui.git (Join-Path $dp "frankentui")
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-11-01
+          toolchain: nightly-2026-06-06
           targets: x86_64-pc-windows-msvc
       - uses: Swatinem/rust-cache@v2
         with:
@@ -609,7 +609,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-11-01
+          toolchain: nightly-2026-06-06
 
       - name: Verify version matches tag
         run: |

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -15,7 +15,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   CARGO_NET_RETRY: 2
-  RUSTUP_TOOLCHAIN: nightly-2025-11-01
+  RUSTUP_TOOLCHAIN: nightly-2026-06-06
 
 jobs:
   build:
@@ -81,7 +81,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-11-01
+          toolchain: nightly-2026-06-06
           targets: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Problem
Every `Build` job (and any release) off `main` fails:
```
error[E0658]: use of unstable library feature `isolate_most_least_significant_one`
error: could not compile `ftui-widgets`
```
The CI/release workflows pin **`nightly-2025-11-01`** (rustc 1.93), which predates stabilization of the integer `isolate_most_least_significant_one` feature. Vendored **ftui-widgets 0.4.1** uses `isolate_lowest_one()` (`crates/ftui-widgets/src/fenwick.rs:251`), so it only compiles on a newer toolchain. The fleet/workers build fine because `rust-toolchain.toml` is unpinned (`channel = "nightly"`); only the **pinned CI** is stale.

## Fix
Bump the pin in all four workflows (`ci.yml`, `e2e.yml`, `release.yml`, `test-release.yml`) to **`nightly-2026-06-06`**.

Probed across installed nightlies to choose a safe target:
| nightly | `isolate_lowest_one()` |
|---|---|
| 2025-11-01 | ❌ E0658 (unstable) |
| 2026-02-19 | ❌ E0658 (unstable) |
| 2026-04-22 | ✅ stable |
| 2026-04-30 | ✅ stable |
| 2026-06-06 | ✅ stable |

`2026-06-06` is already in fleet use and matches the unpinned channel the workers build with. (Doc-comment/test-fixture references to the old nightly string in `rch-common` are intentionally left unchanged — they're illustrative/string-matching tests, not the CI pin.)

## Why this matters
Unblocks all PR/main CI and releases — including the scheduler fix in #21. If this surfaces new clippy `-D warnings` on the newer toolchain, those are pre-existing lint debt exposed by the bump (not introduced here) and can be addressed in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)