### PR TITLE
fix(update): tolerate missing cosign / --skip-verify in signature verification

### DIFF
--- a/rch/src/update/download.rs
+++ b/rch/src/update/download.rs
@@ -47,9 +47,20 @@ impl Drop for UpdateDownloadDir {
 }
 
 /// Download and verify a release.
+/// Decide whether to *enforce* sigstore signature verification for a release.
+///
+/// The signature is a hard gate only when a bundle is published, the operator
+/// has not passed `--skip-verify`, and `cosign` is available. On hosts without
+/// cosign (e.g. the worker fleet) verification degrades to a warning so
+/// `rch update` still works; the checksum is enforced regardless.
+fn should_enforce_signature(has_bundle: bool, skip_verify: bool, cosign_available: bool) -> bool {
+    has_bundle && !skip_verify && cosign_available
+}
+
 pub async fn download_release(
     ctx: &OutputContext,
     update: &UpdateCheck,
+    skip_verify: bool,
 ) -> Result<DownloadedRelease, UpdateError> {
     // Find the asset for our platform.
     let archive_asset = find_archive_asset(&update.assets, &update.latest_version.to_string())?;
@@ -111,24 +122,47 @@ pub async fn download_release(
             .iter()
             .find(|a| a.name == format!("{}.sigstore.json", archive_asset.name));
 
-        let signature_bundle_path = if let Some(sig_asset) = signature_bundle_asset {
-            if !ctx.is_json() {
-                println!("Verifying signature (sigstore bundle)...");
+        let cosign_available = which::which("cosign").is_ok();
+        let signature_bundle_path = match signature_bundle_asset {
+            Some(sig_asset) if should_enforce_signature(true, skip_verify, cosign_available) => {
+                if !ctx.is_json() {
+                    println!("Verifying signature (sigstore bundle)...");
+                }
+                let sig_path = asset_temp_path(temp_dir.path(), &sig_asset.name)?;
+                download_with_retry(
+                    &sig_asset.browser_download_url,
+                    &sig_path,
+                    &sig_asset.name,
+                    MAX_DOWNLOAD_ATTEMPTS,
+                )
+                .await?;
+                Some(sig_path)
             }
-            let sig_path = asset_temp_path(temp_dir.path(), &sig_asset.name)?;
-            download_with_retry(
-                &sig_asset.browser_download_url,
-                &sig_path,
-                &sig_asset.name,
-                MAX_DOWNLOAD_ATTEMPTS,
-            )
-            .await?;
-            Some(sig_path)
-        } else {
-            if !ctx.is_json() {
-                println!("Warning: No sigstore bundle available, skipping signature verification");
+            Some(_) => {
+                // A bundle was published but verification is disabled — either the
+                // operator passed --skip-verify or cosign is unavailable on this
+                // host. Degrade to a warning; the checksum below is still enforced.
+                if !ctx.is_json() {
+                    if skip_verify {
+                        println!(
+                            "Warning: skipping signature verification (--skip-verify); checksum still enforced"
+                        );
+                    } else {
+                        println!(
+                            "Warning: cosign not found in PATH; skipping signature verification (checksum still enforced)"
+                        );
+                    }
+                }
+                None
             }
-            None
+            None => {
+                if !ctx.is_json() {
+                    println!(
+                        "Warning: No sigstore bundle available, skipping signature verification"
+                    );
+                }
+                None
+            }
         };
 
         let verification = if let Some(bundle_path) = signature_bundle_path.as_deref() {
@@ -422,6 +456,18 @@ mod tests {
     use super::super::types::ReleaseAsset;
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn signature_enforced_only_with_bundle_cosign_and_no_skip() {
+        // Full enforcement: a bundle is published, no --skip-verify, cosign present.
+        assert!(should_enforce_signature(true, false, true));
+        // No bundle published -> nothing to enforce.
+        assert!(!should_enforce_signature(false, false, true));
+        // Operator opted out with --skip-verify.
+        assert!(!should_enforce_signature(true, true, true));
+        // cosign unavailable (e.g. the worker fleet) -> degrade to checksum-only.
+        assert!(!should_enforce_signature(true, false, false));
+    }
 
     fn test_asset(name: &str) -> ReleaseAsset {
         ReleaseAsset {

--- a/rch/src/update/mod.rs
+++ b/rch/src/update/mod.rs
@@ -100,7 +100,7 @@ pub async fn run_update(
     }
 
     // Download and verify
-    let download = download_release(ctx, &update_info).await?;
+    let download = download_release(ctx, &update_info, skip_verify).await?;
 
     if !download.checksum_verified {
         let asset = download


### PR DESCRIPTION
Brings the **self-updater cosign-tolerance fix** to `main`. `main`'s updater still hard-aborts (`which("cosign")?` at `verify.rs:156`) whenever a release ships a `*.sigstore.json` bundle but `cosign` is absent — which is the entire worker fleet — so cosign-less hosts cannot `rch update`. `--skip-verify` only gated the checksum, never the signature.

This makes signature verification a hard gate **only** when a bundle is published AND `--skip-verify` was not passed AND `cosign` is available; otherwise it degrades to a warning and the **checksum stays enforced**. Adds a pure `should_enforce_signature(has_bundle, skip_verify, cosign_available)` helper (+ truth-table unit test) and threads `skip_verify` through `download_release`.

### Provenance / verification
- Cherry-picked (`-x`) from the **v1.0.44 release line** (`release/1.0.44`, commit `d67e602`), where it shipped and was **compiled, clippy `-D warnings` clean, and unit-tested** (incl. the new truth-table test).
- Applies cleanly onto `main` — only touches `rch/src/update/{download.rs,mod.rs}`; **does not disturb `main`'s crates.io-deps direction** (rch#23).
- ⚠️ GitHub Actions is currently gridlocked (50h+ queue), so CI checks may not run promptly on this PR. The change was validated locally on the identical updater code.

### Why it matters
Without this, every worker needs a manual tarball deploy on each release. With it, `rch update` works fleet-wide. (v1.0.44 was already deployed to the fleet this way to break the chicken-and-egg.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)