### PR TITLE
feat: offload Go and TypeScript builds to remote workers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3822,7 +3822,7 @@ dependencies = [
 
 [[package]]
 name = "rch"
-version = "1.0.48"
+version = "1.0.49"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3884,7 +3884,7 @@ dependencies = [
 
 [[package]]
 name = "rch-common"
-version = "1.0.48"
+version = "1.0.49"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3918,7 +3918,7 @@ dependencies = [
 
 [[package]]
 name = "rch-telemetry"
-version = "1.0.48"
+version = "1.0.49"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3943,7 +3943,7 @@ dependencies = [
 
 [[package]]
 name = "rch-wkr"
-version = "1.0.48"
+version = "1.0.49"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3964,7 +3964,7 @@ dependencies = [
 
 [[package]]
 name = "rchd"
-version = "1.0.48"
+version = "1.0.49"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3822,7 +3822,7 @@ dependencies = [
 
 [[package]]
 name = "rch"
-version = "1.0.47"
+version = "1.0.48"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3884,7 +3884,7 @@ dependencies = [
 
 [[package]]
 name = "rch-common"
-version = "1.0.47"
+version = "1.0.48"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3918,7 +3918,7 @@ dependencies = [
 
 [[package]]
 name = "rch-telemetry"
-version = "1.0.47"
+version = "1.0.48"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3943,7 +3943,7 @@ dependencies = [
 
 [[package]]
 name = "rch-wkr"
-version = "1.0.47"
+version = "1.0.48"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3964,7 +3964,7 @@ dependencies = [
 
 [[package]]
 name = "rchd"
-version = "1.0.47"
+version = "1.0.48"
 dependencies = [
  "anyhow",
  "axum",
@@ -6296,3 +6296,83 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[patch.unused]]
+name = "fsqlite"
+version = "0.1.16"
+
+[[patch.unused]]
+name = "fsqlite-ast"
+version = "0.1.16"
+
+[[patch.unused]]
+name = "fsqlite-btree"
+version = "0.1.16"
+
+[[patch.unused]]
+name = "fsqlite-core"
+version = "0.1.16"
+
+[[patch.unused]]
+name = "fsqlite-error"
+version = "0.1.16"
+
+[[patch.unused]]
+name = "fsqlite-ext-fts5"
+version = "0.1.16"
+
+[[patch.unused]]
+name = "fsqlite-ext-icu"
+version = "0.1.16"
+
+[[patch.unused]]
+name = "fsqlite-ext-json"
+version = "0.1.16"
+
+[[patch.unused]]
+name = "fsqlite-ext-misc"
+version = "0.1.16"
+
+[[patch.unused]]
+name = "fsqlite-ext-rtree"
+version = "0.1.16"
+
+[[patch.unused]]
+name = "fsqlite-func"
+version = "0.1.16"
+
+[[patch.unused]]
+name = "fsqlite-mvcc"
+version = "0.1.16"
+
+[[patch.unused]]
+name = "fsqlite-observability"
+version = "0.1.16"
+
+[[patch.unused]]
+name = "fsqlite-pager"
+version = "0.1.16"
+
+[[patch.unused]]
+name = "fsqlite-parser"
+version = "0.1.16"
+
+[[patch.unused]]
+name = "fsqlite-planner"
+version = "0.1.16"
+
+[[patch.unused]]
+name = "fsqlite-types"
+version = "0.1.16"
+
+[[patch.unused]]
+name = "fsqlite-vdbe"
+version = "0.1.16"
+
+[[patch.unused]]
+name = "fsqlite-vfs"
+version = "0.1.16"
+
+[[patch.unused]]
+name = "fsqlite-wal"
+version = "0.1.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.48"
+version = "1.0.49"
 edition = "2024"
 license = "MIT"
 authors = ["Remote Compilation Helper Contributors"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.47"
+version = "1.0.48"
 edition = "2024"
 license = "MIT"
 authors = ["Remote Compilation Helper Contributors"]

--- a/rch-common/src/admit_preflight.rs
+++ b/rch-common/src/admit_preflight.rs
@@ -58,6 +58,10 @@ pub struct RequiredCapabilities {
     pub needs_bun: bool,
     /// Whether the command requires nix (binary + populated `/nix/store`).
     pub needs_nix: bool,
+    /// Whether the command requires the Go toolchain.
+    pub needs_go: bool,
+    /// Whether the command requires Node.js (e.g. `tsc` / `npx tsc`).
+    pub needs_node: bool,
     /// rustup targets the command explicitly requests (`--target <triple>`).
     pub needs_targets: Vec<String>,
     /// Explicit toolchain overrides (`cargo +nightly-…`).
@@ -75,6 +79,8 @@ impl RequiredCapabilities {
             needs_cargo: self.needs_cargo,
             needs_bun: self.needs_bun,
             needs_nix: self.needs_nix,
+            needs_go: self.needs_go,
+            needs_node: self.needs_node,
             needs_toolchains: self.needs_toolchains.clone(),
             ..CapabilityRequirement::default()
         }
@@ -126,6 +132,10 @@ fn family_token(kind: CompilationKind) -> &'static str {
         CompilationKind::BunTest => "bun_test",
         CompilationKind::BunTypecheck => "bun_typecheck",
         CompilationKind::NixBuild => "nix_build",
+        CompilationKind::GoBuild => "go_build",
+        CompilationKind::GoTest => "go_test",
+        CompilationKind::GoVet => "go_vet",
+        CompilationKind::Tsc => "tsc",
     }
 }
 
@@ -154,6 +164,11 @@ fn derive_capabilities(command: &str, kind: Option<CompilationKind>) -> Required
             CompilationKind::BunTest | CompilationKind::BunTypecheck
         );
         req.needs_nix = matches!(kind, CompilationKind::NixBuild);
+        req.needs_go = matches!(
+            kind,
+            CompilationKind::GoBuild | CompilationKind::GoTest | CompilationKind::GoVet
+        );
+        req.needs_node = matches!(kind, CompilationKind::Tsc);
     }
     // Scan tokens for `--target <triple>` / `--target=<triple>` and `+toolchain`.
     let tokens: Vec<&str> = command.split_whitespace().collect();
@@ -217,6 +232,8 @@ pub fn preflight(command: &str, proof_policy: bool) -> AdmitPreflight {
             required.needs_cargo |= part_req.needs_cargo;
             required.needs_bun |= part_req.needs_bun;
             required.needs_nix |= part_req.needs_nix;
+            required.needs_go |= part_req.needs_go;
+            required.needs_node |= part_req.needs_node;
             required.needs_targets.extend(part_req.needs_targets);
             required.needs_toolchains.extend(part_req.needs_toolchains);
         }

--- a/rch-common/src/capability_probe.rs
+++ b/rch-common/src/capability_probe.rs
@@ -120,6 +120,8 @@ pub fn build_capability_probe_script(spec: &ProbeSpec) -> String {
     s.push_str(
         "npmv=$(npm --version 2>/dev/null) && printf '%snpm_version=%s\\n' \"$P\" \"$npmv\"; ",
     );
+    // Go toolchain (PATH-resolved; advisory fact gating go build/test/vet routing).
+    s.push_str("gov=$(go version 2>/dev/null) && printf '%sgo_version=%s\\n' \"$P\" \"$gov\"; ");
     // Nix: only report a version when a populated `/nix/store` also exists, since
     // a `nix` binary without a store cannot build derivations (gates nix routing).
     s.push_str(
@@ -198,6 +200,7 @@ pub fn parse_capability_probe(stdout: &str) -> ProbedFacts {
             "node_version" => f.runtimes.node_version = Some(value.to_string()),
             "npm_version" => f.runtimes.npm_version = Some(value.to_string()),
             "nix_version" => f.runtimes.nix_version = Some(value.to_string()),
+            "go_version" => f.runtimes.go_version = Some(value.to_string()),
             "disk" => {
                 // path;total_kb;avail_kb;avail_inodes
                 let parts: Vec<&str> = value.split(';').collect();
@@ -244,6 +247,8 @@ pub struct CapabilityRequirement {
     pub needs_bun: bool,
     /// Whether a working `node` runtime is required.
     pub needs_node: bool,
+    /// Whether a working Go toolchain is required.
+    pub needs_go: bool,
     /// Whether a working `nix` (binary + populated `/nix/store`) is required.
     pub needs_nix: bool,
     /// Specific rustup toolchains the build needs (prefix-matched against the
@@ -419,6 +424,12 @@ pub fn assess_admissibility(facts: &ProbedFacts, req: &CapabilityRequirement) ->
         return CapabilityVerdict::Rejected {
             reason: IncidentReasonCode::MissingRuntimeToolchainTarget,
             detail: "nix (binary + populated /nix/store) not found on the worker".to_string(),
+        };
+    }
+    if req.needs_go && facts.runtimes.go_version.is_none() {
+        return CapabilityVerdict::Rejected {
+            reason: IncidentReasonCode::MissingRuntimeToolchainTarget,
+            detail: "go toolchain not found at the configured user/path".to_string(),
         };
     }
     CapabilityVerdict::Admissible

--- a/rch-common/src/cargo_path_deps.rs
+++ b/rch-common/src/cargo_path_deps.rs
@@ -1,9 +1,14 @@
 //! Cargo local path-dependency graph resolver.
 //!
-//! The resolver builds a deterministic graph of local `path` dependencies using
-//! a two-phase strategy:
+//! The resolver builds a deterministic active graph of local `path` dependencies
+//! using a two-phase strategy:
 //! 1. `cargo metadata` (primary source of truth when available)
 //! 2. Recursive manifest parsing fallback (for malformed metadata and metadata failures)
+//!
+//! A separate manifest-derived materialization closure covers every local path
+//! that Cargo may need under another feature, target, or test selection. Keeping
+//! that closure separate preserves Cargo's cycle-free active execution graph
+//! while still making inactive optional cycles available to remote workers.
 //!
 //! Every discovered path is normalized through [`PathTopologyPolicy`] to enforce
 //! canonical-root safety and stable path identity.
@@ -28,6 +33,27 @@ pub struct CargoPathDependencyGraph {
     /// Reachable local packages in deterministic order.
     pub packages: Vec<CargoPathDependencyPackage>,
     /// Reachable path-dependency edges in deterministic order.
+    pub edges: Vec<CargoPathDependencyEdge>,
+}
+
+/// Deterministic, cycle-tolerant closure of local Cargo packages that must be
+/// materialized on a remote worker.
+///
+/// Unlike [`CargoPathDependencyGraph`], this closure includes inactive optional,
+/// development, build, target-specific, workspace-inherited, and path-patched
+/// edges. Its edges are evidence, not an execution DAG, and may contain cycles.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CargoPathMaterializationClosure {
+    /// Canonical path to the entry manifest used for resolution.
+    pub entry_manifest_path: PathBuf,
+    /// Canonical workspace root when entrypoint is a workspace manifest.
+    pub workspace_root: Option<PathBuf>,
+    /// Canonical root packages used as traversal roots (sorted).
+    pub root_packages: Vec<PathBuf>,
+    /// Every reachable local package in deterministic order.
+    pub packages: Vec<CargoPathDependencyPackage>,
+    /// Every reachable path-dependency edge in deterministic order.
+    /// Cycles are retained and do not make the closure invalid.
     pub edges: Vec<CargoPathDependencyEdge>,
 }
 
@@ -214,6 +240,30 @@ pub fn resolve_cargo_path_dependency_graph_with_policy(
         policy,
         invoke_cargo_metadata,
     )
+}
+
+/// Resolve every local Cargo package that may need source materialization using
+/// the default topology policy.
+pub fn resolve_cargo_path_materialization_closure(
+    entrypoint: &Path,
+) -> Result<CargoPathMaterializationClosure, CargoPathDependencyError> {
+    resolve_cargo_path_materialization_closure_with_policy(
+        entrypoint,
+        &PathTopologyPolicy::default(),
+    )
+}
+
+/// Resolve every local Cargo package that may need source materialization using
+/// an explicit topology policy.
+///
+/// Resolution is manifest-only by design: it never imports user-home Cargo
+/// configuration, and it includes inactive edges that `cargo metadata` omits.
+pub fn resolve_cargo_path_materialization_closure_with_policy(
+    entrypoint: &Path,
+    policy: &PathTopologyPolicy,
+) -> Result<CargoPathMaterializationClosure, CargoPathDependencyError> {
+    let entry_manifest = resolve_entry_manifest(entrypoint, policy)?;
+    resolve_materialization_from_manifests(&entry_manifest, policy)
 }
 
 fn resolve_cargo_path_dependency_graph_with_policy_and_provider<F>(
@@ -1076,6 +1126,7 @@ struct ManifestDocument {
     workspace_path_dependencies: BTreeMap<String, String>,
     patch_path_dependencies: BTreeMap<String, String>,
     path_dependencies: Vec<ManifestDependency>,
+    materialization_path_dependencies: Vec<ManifestDependency>,
 }
 
 #[derive(Debug, Clone)]
@@ -1163,6 +1214,303 @@ fn resolve_from_manifest_fallback(
     }
 
     finalize_graph(entry_manifest_path.to_path_buf(), partial)
+}
+
+fn resolve_materialization_from_manifests(
+    entry_manifest_path: &Path,
+    policy: &PathTopologyPolicy,
+) -> Result<CargoPathMaterializationClosure, CargoPathDependencyError> {
+    let entry_manifest = read_manifest_document(entry_manifest_path)?;
+    let entry_root = entry_manifest_path.parent().ok_or_else(|| {
+        CargoPathDependencyError::new(
+            CargoPathDependencyErrorKind::ManifestParseFailure,
+            format!(
+                "entry manifest has no parent: {}",
+                entry_manifest_path.display()
+            ),
+        )
+        .with_manifest_path(entry_manifest_path)
+    })?;
+    let entry_root = normalize_path_for_policy(
+        entry_root,
+        policy,
+        Some(entry_manifest_path),
+        None,
+        "normalize materialization entry root",
+    )?;
+
+    let mut partial = PartialGraph::default();
+    if entry_manifest.has_workspace {
+        partial.workspace_root = Some(entry_root.clone());
+    }
+    let workspace_path_dependencies = entry_manifest.workspace_path_dependencies.clone();
+    let patch_path_dependencies = entry_manifest.patch_path_dependencies.clone();
+    let workspace_member_manifests = expand_workspace_members(
+        &entry_root,
+        &entry_manifest.workspace_members,
+        entry_manifest_path,
+    )?;
+    let workspace_member_set = workspace_member_manifests
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let include_entry_manifest =
+        entry_manifest.package_name.is_some() || workspace_member_set.is_empty();
+
+    let mut manifest_cache = BTreeMap::from([(entry_manifest_path.to_path_buf(), entry_manifest)]);
+    let mut visited = BTreeSet::new();
+
+    for manifest_path in &workspace_member_set {
+        visit_manifest_for_materialization(
+            manifest_path,
+            policy,
+            &entry_root,
+            &workspace_member_set,
+            &workspace_path_dependencies,
+            &patch_path_dependencies,
+            true,
+            &mut partial,
+            &mut manifest_cache,
+            &mut visited,
+        )?;
+    }
+    if include_entry_manifest {
+        visit_manifest_for_materialization(
+            entry_manifest_path,
+            policy,
+            &entry_root,
+            &workspace_member_set,
+            &workspace_path_dependencies,
+            &patch_path_dependencies,
+            true,
+            &mut partial,
+            &mut manifest_cache,
+            &mut visited,
+        )?;
+    }
+
+    for (dependency_name, raw_dependency_path) in workspace_path_dependencies
+        .iter()
+        .chain(patch_path_dependencies.iter())
+    {
+        let dependency_candidate = resolve_dependency_candidate(&entry_root, raw_dependency_path);
+        let (_, dependency_manifest) = resolve_materialization_dependency_manifest(
+            &dependency_candidate,
+            policy,
+            entry_manifest_path,
+            dependency_name,
+        )?;
+        visit_manifest_for_materialization(
+            &dependency_manifest,
+            policy,
+            &entry_root,
+            &workspace_member_set,
+            &workspace_path_dependencies,
+            &patch_path_dependencies,
+            false,
+            &mut partial,
+            &mut manifest_cache,
+            &mut visited,
+        )?;
+    }
+
+    Ok(finalize_materialization_closure(
+        entry_manifest_path.to_path_buf(),
+        partial,
+    ))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn visit_manifest_for_materialization(
+    manifest_path: &Path,
+    policy: &PathTopologyPolicy,
+    workspace_root: &Path,
+    workspace_member_manifests: &BTreeSet<PathBuf>,
+    workspace_path_dependencies: &BTreeMap<String, String>,
+    patch_path_dependencies: &BTreeMap<String, String>,
+    mark_workspace_member: bool,
+    partial: &mut PartialGraph,
+    manifest_cache: &mut BTreeMap<PathBuf, ManifestDocument>,
+    visited: &mut BTreeSet<PathBuf>,
+) -> Result<(), CargoPathDependencyError> {
+    let manifest_root = manifest_path.parent().ok_or_else(|| {
+        CargoPathDependencyError::new(
+            CargoPathDependencyErrorKind::ManifestParseFailure,
+            format!("manifest has no parent: {}", manifest_path.display()),
+        )
+        .with_manifest_path(manifest_path)
+    })?;
+    let package_root = normalize_path_for_policy(
+        manifest_root,
+        policy,
+        Some(manifest_path),
+        None,
+        "normalize materialization package root",
+    )?;
+    let canonical_manifest = package_root.join("Cargo.toml");
+    if !canonical_manifest.is_file() {
+        return Err(CargoPathDependencyError::new(
+            CargoPathDependencyErrorKind::ManifestParseFailure,
+            format!("manifest file missing: {}", canonical_manifest.display()),
+        )
+        .with_manifest_path(canonical_manifest));
+    }
+
+    if !visited.insert(package_root.clone()) {
+        if mark_workspace_member {
+            partial.add_root(package_root.clone());
+            if let Some(package) = partial.packages.get_mut(&package_root) {
+                package.workspace_member = true;
+            }
+        }
+        return Ok(());
+    }
+
+    let manifest = if let Some(cached) = manifest_cache.get(&canonical_manifest) {
+        cached.clone()
+    } else {
+        let parsed = read_manifest_document(&canonical_manifest)?;
+        manifest_cache.insert(canonical_manifest.clone(), parsed.clone());
+        parsed
+    };
+
+    let workspace_member =
+        mark_workspace_member || workspace_member_manifests.contains(&canonical_manifest);
+    partial.add_package(
+        package_root.clone(),
+        canonical_manifest.clone(),
+        manifest
+            .package_name
+            .clone()
+            .unwrap_or_else(|| default_package_name(&package_root)),
+        workspace_member,
+    );
+    if workspace_member {
+        partial.add_root(package_root.clone());
+    }
+
+    for dependency in &manifest.materialization_path_dependencies {
+        let Some(dependency_candidate) = resolve_manifest_dependency_candidate(
+            &package_root,
+            workspace_root,
+            dependency,
+            workspace_path_dependencies,
+            patch_path_dependencies,
+        ) else {
+            continue;
+        };
+        let (dependency_root, dependency_manifest) = resolve_materialization_dependency_manifest(
+            &dependency_candidate,
+            policy,
+            &canonical_manifest,
+            &dependency.dependency_name,
+        )?;
+
+        partial.add_edge(
+            package_root.clone(),
+            dependency_root,
+            dependency.dependency_name.clone(),
+        );
+        visit_manifest_for_materialization(
+            &dependency_manifest,
+            policy,
+            workspace_root,
+            workspace_member_manifests,
+            workspace_path_dependencies,
+            patch_path_dependencies,
+            false,
+            partial,
+            manifest_cache,
+            visited,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn resolve_materialization_dependency_manifest(
+    dependency_candidate: &Path,
+    policy: &PathTopologyPolicy,
+    declaring_manifest: &Path,
+    dependency_name: &str,
+) -> Result<(PathBuf, PathBuf), CargoPathDependencyError> {
+    validate_absolute_dependency_scope(
+        dependency_candidate,
+        policy,
+        declaring_manifest,
+        dependency_name,
+        "materialization dependency path policy violation",
+    )?;
+    if !dependency_candidate.exists() {
+        return Err(CargoPathDependencyError::new(
+            CargoPathDependencyErrorKind::MissingPathDependency,
+            format!(
+                "materialization dependency path does not exist: {}",
+                dependency_candidate.display()
+            ),
+        )
+        .with_manifest_path(declaring_manifest)
+        .with_dependency_name(dependency_name.to_string())
+        .with_dependency_path(dependency_candidate));
+    }
+
+    let dependency_root = normalize_path_for_policy(
+        dependency_candidate,
+        policy,
+        Some(declaring_manifest),
+        Some(dependency_name),
+        "normalize materialization dependency path",
+    )?;
+    let dependency_manifest = dependency_root.join("Cargo.toml");
+    if !dependency_manifest.is_file() {
+        return Err(CargoPathDependencyError::new(
+            CargoPathDependencyErrorKind::MissingPathDependency,
+            format!(
+                "materialization dependency manifest missing: {}",
+                dependency_manifest.display()
+            ),
+        )
+        .with_manifest_path(declaring_manifest)
+        .with_dependency_name(dependency_name.to_string())
+        .with_dependency_path(dependency_manifest.clone()));
+    }
+
+    Ok((dependency_root, dependency_manifest))
+}
+
+fn finalize_materialization_closure(
+    entry_manifest_path: PathBuf,
+    partial: PartialGraph,
+) -> CargoPathMaterializationClosure {
+    let packages = partial
+        .packages
+        .iter()
+        .map(|(root, package)| CargoPathDependencyPackage {
+            package_root: root.clone(),
+            manifest_path: package.manifest_path.clone(),
+            package_name: package.package_name.clone(),
+            workspace_member: package.workspace_member,
+        })
+        .collect();
+    let edges = partial
+        .adjacency
+        .iter()
+        .flat_map(|(from, tails)| {
+            tails.iter().map(|tail| CargoPathDependencyEdge {
+                from: from.clone(),
+                to: tail.to.clone(),
+                dependency_name: tail.dependency_name.clone(),
+            })
+        })
+        .collect();
+
+    CargoPathMaterializationClosure {
+        entry_manifest_path,
+        workspace_root: partial.workspace_root,
+        root_packages: partial.roots.into_iter().collect(),
+        packages,
+        edges,
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1433,17 +1781,48 @@ fn read_manifest_document(
         .unwrap_or_default();
 
     let mut path_dependencies = Vec::new();
-    collect_dependency_specs(table.get("dependencies"), &mut path_dependencies);
-    collect_dependency_specs(table.get("build-dependencies"), &mut path_dependencies);
+    collect_dependency_specs(table.get("dependencies"), &mut path_dependencies, false);
+    collect_dependency_specs(
+        table.get("build-dependencies"),
+        &mut path_dependencies,
+        false,
+    );
 
     if let Some(targets) = table.get("target").and_then(toml::Value::as_table) {
         for target_config in targets.values() {
             if let Some(target_table) = target_config.as_table() {
-                collect_dependency_specs(target_table.get("dependencies"), &mut path_dependencies);
+                collect_dependency_specs(
+                    target_table.get("dependencies"),
+                    &mut path_dependencies,
+                    false,
+                );
                 collect_dependency_specs(
                     target_table.get("build-dependencies"),
                     &mut path_dependencies,
+                    false,
                 );
+            }
+        }
+    }
+
+    let mut materialization_path_dependencies = Vec::new();
+    for dependency_table in ["dependencies", "build-dependencies", "dev-dependencies"] {
+        collect_dependency_specs(
+            table.get(dependency_table),
+            &mut materialization_path_dependencies,
+            true,
+        );
+    }
+    if let Some(targets) = table.get("target").and_then(toml::Value::as_table) {
+        for target_config in targets.values() {
+            if let Some(target_table) = target_config.as_table() {
+                for dependency_table in ["dependencies", "build-dependencies", "dev-dependencies"] {
+                    collect_dependency_specs(
+                        target_table.get(dependency_table),
+                        &mut materialization_path_dependencies,
+                        true,
+                    );
+                }
             }
         }
     }
@@ -1455,12 +1834,14 @@ fn read_manifest_document(
         workspace_path_dependencies,
         patch_path_dependencies,
         path_dependencies,
+        materialization_path_dependencies,
     })
 }
 
 fn collect_dependency_specs(
     maybe_table_value: Option<&toml::Value>,
     collector: &mut Vec<ManifestDependency>,
+    include_optional: bool,
 ) {
     let Some(table) = maybe_table_value.and_then(toml::Value::as_table) else {
         return;
@@ -1475,10 +1856,11 @@ fn collect_dependency_specs(
                 });
             }
             toml::Value::Table(dependency_table) => {
-                if dependency_table
-                    .get("optional")
-                    .and_then(toml::Value::as_bool)
-                    .unwrap_or(false)
+                if !include_optional
+                    && dependency_table
+                        .get("optional")
+                        .and_then(toml::Value::as_bool)
+                        .unwrap_or(false)
                 {
                     continue;
                 }
@@ -2088,17 +2470,198 @@ optional_a = { path = "../optional_a", optional = true }
 
         let graph = resolve_cargo_path_dependency_graph_with_policy(&app_root, &fixture.policy())
             .expect("optional cycle should not poison active dependency closure");
+        let materialization =
+            resolve_cargo_path_materialization_closure_with_policy(&app_root, &fixture.policy())
+                .expect("optional cycle should terminate in materialization closure");
 
         let app_root = app_root.canonicalize().expect("canonical app");
         let real_dep_root = real_dep_root.canonicalize().expect("canonical real dep");
+        let optional_a_root = optional_a_root
+            .canonicalize()
+            .expect("canonical optional a");
+        let optional_b_root = optional_b_root
+            .canonicalize()
+            .expect("canonical optional b");
         assert_eq!(graph.root_packages, vec![app_root.clone()]);
         assert_eq!(
             graph.edges,
             vec![CargoPathDependencyEdge {
-                from: app_root,
-                to: real_dep_root,
+                from: app_root.clone(),
+                to: real_dep_root.clone(),
                 dependency_name: "real_dep".to_string(),
             }]
+        );
+
+        let materialized_roots = materialization
+            .packages
+            .iter()
+            .map(|package| package.package_root.clone())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            materialized_roots,
+            BTreeSet::from([
+                app_root.clone(),
+                real_dep_root.clone(),
+                optional_a_root.clone(),
+                optional_b_root.clone(),
+            ]),
+            "inactive optional packages must still be available for remote materialization"
+        );
+        assert_eq!(
+            materialization
+                .edges
+                .iter()
+                .cloned()
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from([
+                CargoPathDependencyEdge {
+                    from: app_root.clone(),
+                    to: real_dep_root,
+                    dependency_name: "real_dep".to_string(),
+                },
+                CargoPathDependencyEdge {
+                    from: optional_a_root.clone(),
+                    to: optional_b_root.clone(),
+                    dependency_name: "optional_b".to_string(),
+                },
+                CargoPathDependencyEdge {
+                    from: optional_b_root,
+                    to: optional_a_root.clone(),
+                    dependency_name: "optional_a".to_string(),
+                },
+                CargoPathDependencyEdge {
+                    from: app_root,
+                    to: optional_a_root,
+                    dependency_name: "optional_a".to_string(),
+                },
+            ]),
+            "materialization evidence should retain the optional cycle without traversing forever"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn materialization_closure_covers_every_manifest_path_dependency_class() {
+        let fixture = TopologyFixture::new("materialization-all-kinds");
+        let scenario_root = fixture
+            .canonical_root
+            .join("materialization_all_dependency_kinds");
+        let workspace_root = scenario_root.join("workspace");
+        let app_root = workspace_root.join("app");
+        let build_dep_root = scenario_root.join("build_dep");
+        let dev_dep_root = scenario_root.join("dev_dep");
+        let optional_dep_root = scenario_root.join("optional_dep");
+        let patched_dep_root = scenario_root.join("patched_dep");
+        let target_dep_root = scenario_root.join("target_dep");
+        let transitive_dep_root = scenario_root.join("transitive_dep");
+        let unused_patch_dep_root = scenario_root.join("unused_patch_dep");
+        let workspace_dep_root = scenario_root.join("workspace_dep");
+
+        write_lib_crate(&build_dep_root, "build_dep", &[]);
+        write_lib_crate(&dev_dep_root, "dev_dep", &[]);
+        write_lib_crate(
+            &optional_dep_root,
+            "optional_dep",
+            &[("transitive_dep", "../transitive_dep")],
+        );
+        write_lib_crate(&patched_dep_root, "patched_dep", &[]);
+        write_lib_crate(&target_dep_root, "target_dep", &[]);
+        write_lib_crate(&transitive_dep_root, "transitive_dep", &[]);
+        write_lib_crate(&unused_patch_dep_root, "unused_patch_dep", &[]);
+        write_lib_crate(&workspace_dep_root, "workspace_dep", &[]);
+
+        fs::create_dir_all(app_root.join("src")).expect("create app src");
+        fs::write(
+            app_root.join("Cargo.toml"),
+            r#"[package]
+name = "materialization_app"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+optional_dep = { path = "../../optional_dep", optional = true }
+patched_dep = "0.1"
+workspace_dep = { workspace = true, optional = true }
+
+[build-dependencies]
+build_dep = { path = "../../build_dep" }
+
+[dev-dependencies]
+dev_dep = { path = "../../dev_dep" }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+target_dep = { path = "../../target_dep" }
+"#,
+        )
+        .expect("write app manifest");
+        fs::write(app_root.join("src/lib.rs"), "pub fn app() {}\n").expect("write app lib");
+        fs::create_dir_all(&workspace_root).expect("create workspace root");
+        fs::write(
+            workspace_root.join("Cargo.toml"),
+            r#"[workspace]
+members = ["app"]
+resolver = "3"
+
+[workspace.dependencies]
+workspace_dep = { path = "../workspace_dep" }
+
+[patch.crates-io]
+patched_dep = { path = "../patched_dep" }
+unused_patch_dep = { path = "../unused_patch_dep" }
+"#,
+        )
+        .expect("write workspace manifest");
+
+        let first = resolve_cargo_path_materialization_closure_with_policy(
+            &workspace_root,
+            &fixture.policy(),
+        )
+        .expect("resolve complete materialization closure");
+        let second = resolve_cargo_path_materialization_closure_with_policy(
+            &workspace_root,
+            &fixture.policy(),
+        )
+        .expect("repeat complete materialization closure");
+        assert_eq!(first, second, "materialization must be deterministic");
+
+        let expected_roots = [
+            &app_root,
+            &build_dep_root,
+            &dev_dep_root,
+            &optional_dep_root,
+            &patched_dep_root,
+            &target_dep_root,
+            &transitive_dep_root,
+            &unused_patch_dep_root,
+            &workspace_dep_root,
+        ]
+        .into_iter()
+        .map(|root| root.canonicalize().expect("canonical fixture package"))
+        .collect::<BTreeSet<_>>();
+        let observed_roots = first
+            .packages
+            .iter()
+            .map(|package| package.package_root.clone())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(observed_roots, expected_roots);
+
+        let dependency_names = first
+            .edges
+            .iter()
+            .map(|edge| edge.dependency_name.as_str())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            dependency_names,
+            BTreeSet::from([
+                "build_dep",
+                "dev_dep",
+                "optional_dep",
+                "patched_dep",
+                "target_dep",
+                "transitive_dep",
+                "workspace_dep",
+            ]),
+            "normal, build, dev, target, optional, workspace, patch, and transitive paths must all materialize"
         );
     }
 

--- a/rch-common/src/dependency_closure_planner.rs
+++ b/rch-common/src/dependency_closure_planner.rs
@@ -10,8 +10,9 @@ use std::path::{Path, PathBuf};
 
 use crate::{
     CargoPathDependencyEdge, CargoPathDependencyError, CargoPathDependencyErrorKind,
-    CargoPathDependencyGraph, CargoPathDependencyPackage, PathTopologyPolicy,
-    resolve_cargo_path_dependency_graph_with_policy,
+    CargoPathDependencyGraph, CargoPathDependencyPackage, CargoPathMaterializationClosure,
+    PathTopologyPolicy, resolve_cargo_path_dependency_graph_with_policy,
+    resolve_cargo_path_materialization_closure_with_policy,
 };
 
 /// Planner-level lifecycle state for dependency closure.
@@ -113,15 +114,59 @@ pub fn build_dependency_closure_plan_with_policy(
     entrypoint: &Path,
     policy: &PathTopologyPolicy,
 ) -> DependencyClosurePlan {
-    match resolve_cargo_path_dependency_graph_with_policy(entrypoint, policy) {
-        Ok(graph) => plan_dependency_closure_from_graph(&graph),
-        Err(error) => fail_open_plan_from_resolver_error(entrypoint, &error),
-    }
+    let graph = match resolve_cargo_path_dependency_graph_with_policy(entrypoint, policy) {
+        Ok(graph) => graph,
+        Err(error) => return fail_open_plan_from_resolver_error(entrypoint, &error),
+    };
+    let materialization_entrypoint = graph.workspace_root.as_deref().unwrap_or(entrypoint);
+    let materialization = match resolve_cargo_path_materialization_closure_with_policy(
+        materialization_entrypoint,
+        policy,
+    ) {
+        Ok(materialization) => materialization,
+        Err(error) => {
+            let mut plan = fail_open_plan_from_resolver_error(entrypoint, &error);
+            plan.issues.insert(
+                0,
+                DependencyPlanIssue {
+                    code: "materialization-closure-unavailable".to_string(),
+                    message: format!(
+                        "Cargo path materialization closure is unavailable: {}: {}",
+                        error.kind(),
+                        error.detail()
+                    ),
+                    risk: DependencyRiskClass::Critical,
+                    diagnostics: vec![
+                        format!(
+                            "materialization_entrypoint={}",
+                            materialization_entrypoint.display()
+                        ),
+                        format!("source_error_kind={}", error.kind()),
+                    ],
+                },
+            );
+            plan.fail_open_reason = Some(format!(
+                "materialization closure produced {}: {}",
+                error.kind(),
+                error.detail()
+            ));
+            return plan;
+        }
+    };
+
+    plan_dependency_closure_from_graph_and_materialization(&graph, Some(&materialization))
 }
 
 /// Convert a resolved graph into deterministic sync actions.
 pub fn plan_dependency_closure_from_graph(
     graph: &CargoPathDependencyGraph,
+) -> DependencyClosurePlan {
+    plan_dependency_closure_from_graph_and_materialization(graph, None)
+}
+
+fn plan_dependency_closure_from_graph_and_materialization(
+    graph: &CargoPathDependencyGraph,
+    materialization: Option<&CargoPathMaterializationClosure>,
 ) -> DependencyClosurePlan {
     let package_by_root: BTreeMap<PathBuf, CargoPathDependencyPackage> = graph
         .packages
@@ -185,7 +230,7 @@ pub fn plan_dependency_closure_from_graph(
     }
 
     let mut sync_order = Vec::with_capacity(order.len());
-    for (order_index, root) in order.iter().enumerate() {
+    for root in &order {
         let package =
             package_by_root
                 .get(root)
@@ -229,13 +274,86 @@ pub fn plan_dependency_closure_from_graph(
         };
 
         sync_order.push(DependencySyncAction {
-            order_index,
+            order_index: 0,
             package_root: package.package_root.clone(),
             manifest_path: package.manifest_path,
             package_name: package.package_name,
             risk,
             metadata,
         });
+    }
+
+    if let Some(materialization) = materialization {
+        let active_roots = graph
+            .packages
+            .iter()
+            .map(|package| package.package_root.clone())
+            .collect::<BTreeSet<_>>();
+        let materialization_roots = materialization
+            .root_packages
+            .iter()
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        let mut materialization_inbound: BTreeMap<PathBuf, BTreeSet<String>> = BTreeMap::new();
+        let mut materialization_dependents: BTreeMap<PathBuf, BTreeSet<PathBuf>> = BTreeMap::new();
+        for edge in &materialization.edges {
+            materialization_inbound
+                .entry(edge.to.clone())
+                .or_default()
+                .insert(edge.dependency_name.clone());
+            materialization_dependents
+                .entry(edge.to.clone())
+                .or_default()
+                .insert(edge.from.clone());
+        }
+
+        let mut materialization_only = Vec::new();
+        for package in &materialization.packages {
+            if active_roots.contains(&package.package_root) {
+                continue;
+            }
+
+            let reason = if package.workspace_member {
+                DependencySyncReason::WorkspaceMember
+            } else {
+                DependencySyncReason::TransitivePathDependency
+            };
+            let inbound_names = materialization_inbound
+                .get(&package.package_root)
+                .map(|set| set.iter().cloned().collect::<Vec<_>>())
+                .unwrap_or_default();
+            let dependents = materialization_dependents
+                .get(&package.package_root)
+                .map(|set| set.iter().cloned().collect::<Vec<_>>())
+                .unwrap_or_default();
+
+            materialization_only.push(DependencySyncAction {
+                order_index: 0,
+                package_root: package.package_root.clone(),
+                manifest_path: package.manifest_path.clone(),
+                package_name: package.package_name.clone(),
+                risk: classify_sync_risk(reason, dependents.len()),
+                metadata: DependencySyncMetadata {
+                    reason,
+                    workspace_member: package.workspace_member,
+                    root_package: materialization_roots.contains(&package.package_root),
+                    inbound_dependency_names: inbound_names,
+                    dependent_roots: dependents.clone(),
+                    notes: vec![
+                        format!("dependent_root_count={}", dependents.len()),
+                        "materialization_only=true".to_string(),
+                        "active_execution_edge=false".to_string(),
+                    ],
+                },
+            });
+        }
+
+        materialization_only.extend(sync_order);
+        sync_order = materialization_only;
+    }
+
+    for (order_index, action) in sync_order.iter_mut().enumerate() {
+        action.order_index = order_index;
     }
 
     let canonical_roots = sync_order
@@ -501,6 +619,98 @@ mod tests {
         assert_eq!(plan.issues.len(), 1);
         assert_eq!(plan.issues[0].code, "planner_non_deterministic_order");
         assert_eq!(plan.issues[0].risk, DependencyRiskClass::Critical);
+    }
+
+    #[test]
+    fn planner_unions_cycle_tolerant_materialization_without_changing_active_dag() {
+        let graph = CargoPathDependencyGraph {
+            entry_manifest_path: PathBuf::from("/data/projects/app/Cargo.toml"),
+            workspace_root: None,
+            root_packages: vec![PathBuf::from("/data/projects/app")],
+            packages: vec![
+                package("/data/projects/app", "app", false),
+                package("/data/projects/real_dep", "real_dep", false),
+            ],
+            edges: vec![edge(
+                "/data/projects/app",
+                "/data/projects/real_dep",
+                "real_dep",
+            )],
+        };
+        let materialization = CargoPathMaterializationClosure {
+            entry_manifest_path: graph.entry_manifest_path.clone(),
+            workspace_root: None,
+            root_packages: graph.root_packages.clone(),
+            packages: vec![
+                package("/data/projects/app", "app", false),
+                package("/data/projects/optional_a", "optional_a", false),
+                package("/data/projects/optional_b", "optional_b", false),
+                package("/data/projects/real_dep", "real_dep", false),
+            ],
+            edges: vec![
+                edge(
+                    "/data/projects/app",
+                    "/data/projects/optional_a",
+                    "optional_a",
+                ),
+                edge("/data/projects/app", "/data/projects/real_dep", "real_dep"),
+                edge(
+                    "/data/projects/optional_a",
+                    "/data/projects/optional_b",
+                    "optional_b",
+                ),
+                edge(
+                    "/data/projects/optional_b",
+                    "/data/projects/optional_a",
+                    "optional_a",
+                ),
+            ],
+        };
+
+        let plan =
+            plan_dependency_closure_from_graph_and_materialization(&graph, Some(&materialization));
+
+        assert!(
+            plan.is_ready(),
+            "inactive optional cycles are materialization evidence, not active DAG edges"
+        );
+        assert_eq!(
+            plan.sync_roots().into_iter().collect::<BTreeSet<_>>(),
+            BTreeSet::from([
+                PathBuf::from("/data/projects/app"),
+                PathBuf::from("/data/projects/optional_a"),
+                PathBuf::from("/data/projects/optional_b"),
+                PathBuf::from("/data/projects/real_dep"),
+            ])
+        );
+        let real_dep_position = plan
+            .sync_order
+            .iter()
+            .position(|action| action.package_name == "real_dep")
+            .expect("active dependency action");
+        let app_position = plan
+            .sync_order
+            .iter()
+            .position(|action| action.package_name == "app")
+            .expect("active entry action");
+        assert!(
+            real_dep_position < app_position,
+            "active dependency-first order must remain intact"
+        );
+        for package_name in ["optional_a", "optional_b"] {
+            let action = plan
+                .sync_order
+                .iter()
+                .find(|action| action.package_name == package_name)
+                .expect("materialization-only action");
+            assert!(
+                action
+                    .metadata
+                    .notes
+                    .iter()
+                    .any(|note| note == "materialization_only=true")
+            );
+        }
     }
 
     #[test]

--- a/rch-common/src/lib.rs
+++ b/rch-common/src/lib.rs
@@ -164,8 +164,10 @@ pub use bypass_recovery::{
 };
 pub use cargo_path_deps::{
     CargoPathDependencyEdge, CargoPathDependencyError, CargoPathDependencyErrorKind,
-    CargoPathDependencyGraph, CargoPathDependencyPackage, resolve_cargo_path_dependency_graph,
-    resolve_cargo_path_dependency_graph_with_policy,
+    CargoPathDependencyGraph, CargoPathDependencyPackage, CargoPathMaterializationClosure,
+    resolve_cargo_path_dependency_graph, resolve_cargo_path_dependency_graph_with_policy,
+    resolve_cargo_path_materialization_closure,
+    resolve_cargo_path_materialization_closure_with_policy,
 };
 pub use closure_explain::{
     ClosureExplainEntry, ClosureExplainReport, RootConvergence, RootSyncOutcome, derive_outcome,

--- a/rch-common/src/patterns.rs
+++ b/rch-common/src/patterns.rs
@@ -2108,7 +2108,10 @@ fn classify_go(cmd: &str) -> Classification {
         }
         "test" => {
             // `-exec` runs an arbitrary local wrapper binary; keep it local.
-            if args.iter().any(|a| a.eq(&"-exec") || a.starts_with("-exec=")) {
+            if args
+                .iter()
+                .any(|a| a.eq(&"-exec") || a.starts_with("-exec="))
+            {
                 return Classification::not_compilation(
                     "go test -exec runs a local wrapper (not intercepted)",
                 );

--- a/rch-common/src/patterns.rs
+++ b/rch-common/src/patterns.rs
@@ -37,6 +37,9 @@ pub static COMPILATION_KEYWORDS: &[&str] = &[
     "nextest",
     "nix",
     "nix-build",
+    "go",
+    "tsc",
+    "npx",
 ];
 
 /// Commands that should NEVER be intercepted, even if they contain compilation keywords.
@@ -93,6 +96,25 @@ pub static NEVER_INTERCEPT: &[&str] = &[
     "cargo nextest list",    // Lists tests only, doesn't run them
     "cargo nextest archive", // Creates test archives
     "cargo nextest show",    // Shows config/setup info
+    // Go commands that mutate local state, run programs, or are trivially fast.
+    // Only `go build` / `go test` / `go vet` are offloadable (see classify_go).
+    "go get",      // mutates go.mod / module cache
+    "go mod",      // mutates go.mod / go.sum
+    "go work",     // mutates go.work
+    "go install",  // writes a binary into local GOBIN
+    "go run",      // runs a program locally (may be interactive / long-lived)
+    "go generate", // executes arbitrary local codegen
+    "go fmt",      // rewrites local source files
+    "go clean",    // mutates local caches
+    "go env",      // trivial; also used to *set* local env
+    "go doc",      // trivial lookup
+    "go version",  // trivial
+    "go tool",     // arbitrary tool execution
+    "go list",     // metadata query; cheap, and agents parse it locally
+    // TypeScript: version/init are trivial or mutate local state
+    "tsc --version",
+    "tsc -v",
+    "tsc --init",
 ];
 
 /// Result of command classification.
@@ -244,6 +266,24 @@ pub enum CompilationKind {
     /// bun typecheck - Runs TypeScript type checking
     BunTypecheck,
 
+    // Go commands
+    //
+    // Only the non-emitting forms are offloaded. `go build -o <file>` writes a
+    // binary the caller expects to find locally, so classify_go declines it and
+    // it runs locally — a remote build whose artifact never came home would be a
+    // silent correctness bug. Plain `go build ./...` is a compile check that
+    // produces no output file, so exit status is the whole payload.
+    /// `go build ./...` (compile check; no `-o` output file)
+    GoBuild,
+    /// `go test ./...`
+    GoTest,
+    /// `go vet ./...`
+    GoVet,
+
+    // TypeScript
+    /// `tsc --noEmit` / `npx tsc --noEmit` (typecheck only; emitting runs stay local)
+    Tsc,
+
     // Nix commands
     /// `nix build` / `nix-build` (derivation build), `nix flake check`
     /// (evaluate + build all outputs), and the non-interactive
@@ -268,6 +308,7 @@ impl CompilationKind {
                 | CompilationKind::CargoNextest
                 | CompilationKind::CargoBench
                 | CompilationKind::BunTest
+                | CompilationKind::GoTest
         )
     }
 
@@ -301,6 +342,11 @@ impl CompilationKind {
             // Nix commands. Both `nix build` and the legacy `nix-build` route
             // through this kind; the canonical allowlist base name is "nix".
             CompilationKind::NixBuild => "nix",
+            // Go commands
+            CompilationKind::GoBuild | CompilationKind::GoTest | CompilationKind::GoVet => "go",
+            // TypeScript. Both `tsc` and `npx tsc` route through this kind; the
+            // canonical allowlist base name is "tsc".
+            CompilationKind::Tsc => "tsc",
         }
     }
 }
@@ -1972,7 +2018,112 @@ fn classify_full(cmd: &str) -> Classification {
         }
     }
 
+    // Go commands
+    if cmd.starts_with("go ") {
+        return classify_go(cmd);
+    }
+
+    // TypeScript: `tsc ...` and `npx tsc ...`.
+    //
+    // `npx` is not a normalize_command wrapper (it can run arbitrary packages),
+    // so match it explicitly here rather than stripping it globally.
+    if let Some(rest) = cmd
+        .strip_prefix("tsc ")
+        .or_else(|| cmd.strip_prefix("npx tsc "))
+    {
+        return classify_tsc(rest);
+    }
+
     Classification::not_compilation("no matching pattern")
+}
+
+/// Classify `tsc` / `npx tsc` invocations.
+///
+/// Only `--noEmit` typechecks are offloaded. An emitting `tsc` run writes `.js`
+/// / `.d.ts` / `.tsbuildinfo` into the local tree, and these kinds are
+/// stream-only (no artifact sync-back), so offloading an emitting run would
+/// return exit 0 with no output files — a silent correctness bug. Emitting runs
+/// stay local.
+///
+/// `args` is the command with the leading `tsc ` / `npx tsc ` already stripped.
+fn classify_tsc(args: &str) -> Classification {
+    let tokens = args.split_whitespace();
+    let mut no_emit = false;
+    for token in tokens {
+        // --watch is interactive and never terminates; never intercept.
+        if token.eq("-w") || token.eq("--watch") || token.eq("--watchFile") {
+            return Classification::not_compilation("tsc --watch is interactive (not intercepted)");
+        }
+        // tsc's flag parsing is case-insensitive (--noemit == --noEmit).
+        if token.eq_ignore_ascii_case("--noemit") {
+            no_emit = true;
+        }
+    }
+
+    if !no_emit {
+        return Classification::not_compilation(
+            "tsc without --noEmit emits output files locally (not intercepted)",
+        );
+    }
+
+    Classification::compilation(CompilationKind::Tsc, 0.95, "tsc --noEmit typecheck")
+}
+
+/// Classify `go` subcommands.
+///
+/// Only `build` (without `-o`), `test`, and `vet` are offloaded. Everything else
+/// is either local-state-mutating or trivially fast and is listed in
+/// [`NEVER_INTERCEPT`]; this function is the second line of defence.
+///
+/// `go build -o <file>` is deliberately NOT offloaded: it writes a binary the
+/// caller expects to find on the local filesystem, and Go kinds are stream-only
+/// (no artifact sync-back). Offloading it would report success while leaving no
+/// binary behind. Plain `go build ./...` writes nothing (it is a compile check),
+/// so exit status is the entire payload and it is safe to run remotely.
+fn classify_go(cmd: &str) -> Classification {
+    let mut tokens = cmd.split_whitespace();
+    // Skip the leading "go".
+    tokens.next();
+
+    let subcommand = match tokens.next() {
+        Some(sub) => sub,
+        None => return Classification::not_compilation("bare `go` is not a compilation command"),
+    };
+
+    // Remaining args, used for flag checks below.
+    let args: Vec<&str> = tokens.collect();
+
+    match subcommand {
+        "build" => {
+            // `-o <file>` (or `-o=<file>`) emits a binary locally — keep it local.
+            if args
+                .iter()
+                .any(|a| a.eq(&"-o") || a.starts_with("-o=") || a.eq(&"--output"))
+            {
+                return Classification::not_compilation(
+                    "go build -o emits a local binary (not intercepted)",
+                );
+            }
+            Classification::compilation(CompilationKind::GoBuild, 0.95, "go build command")
+        }
+        "test" => {
+            // `-exec` runs an arbitrary local wrapper binary; keep it local.
+            if args.iter().any(|a| a.eq(&"-exec") || a.starts_with("-exec=")) {
+                return Classification::not_compilation(
+                    "go test -exec runs a local wrapper (not intercepted)",
+                );
+            }
+            // `-c` compiles the test binary to disk instead of running it.
+            if args.iter().any(|a| a.eq(&"-c")) {
+                return Classification::not_compilation(
+                    "go test -c emits a local test binary (not intercepted)",
+                );
+            }
+            Classification::compilation(CompilationKind::GoTest, 0.95, "go test command")
+        }
+        "vet" => Classification::compilation(CompilationKind::GoVet, 0.95, "go vet command"),
+        _ => Classification::not_compilation("go subcommand is not a compilation command"),
+    }
 }
 
 /// Classify cargo subcommands.
@@ -6588,11 +6739,23 @@ mod regression_classification {
                 reason_contains: "no compilation keyword",
                 min_confidence: 0.0,
             },
+            // Go is now a first-class offload target (previously this asserted
+            // "no compilation keyword", i.e. that `go build` was NOT intercepted
+            // and therefore ran locally on the orchestrator).
             Case {
                 cmd: "go build .",
+                expect_compilation: true,
+                expected_kind: Some(CompilationKind::GoBuild),
+                reason_contains: "go build command",
+                min_confidence: 0.9,
+            },
+            // …but an emitting `go build -o` still runs locally: Go kinds are
+            // stream-only, so offloading it would leave no binary behind.
+            Case {
+                cmd: "go build -o bin/app ./cmd/app",
                 expect_compilation: false,
                 expected_kind: None,
-                reason_contains: "no compilation keyword",
+                reason_contains: "emits a local binary",
                 min_confidence: 0.0,
             },
             Case {
@@ -7051,5 +7214,165 @@ mod regression_classification {
         assert_eq!(CompilationKind::Meson.command_base(), "meson");
         assert_eq!(CompilationKind::BunTest.command_base(), "bun");
         assert_eq!(CompilationKind::BunTypecheck.command_base(), "bun");
+    }
+}
+
+#[cfg(test)]
+mod tests_go_and_typescript {
+    use super::*;
+
+    fn kind_of(cmd: &str) -> Option<CompilationKind> {
+        classify_command(cmd).kind
+    }
+
+    // --- Go: the offloadable forms ---
+
+    #[test]
+    fn go_build_test_vet_are_classified() {
+        assert_eq!(kind_of("go build ./..."), Some(CompilationKind::GoBuild));
+        assert_eq!(kind_of("go test ./..."), Some(CompilationKind::GoTest));
+        assert_eq!(kind_of("go vet ./..."), Some(CompilationKind::GoVet));
+        // Real commands observed hammering the orchestrator.
+        assert_eq!(
+            kind_of("go test -tags=e2e ./e2e -run ^TestE2EAtomicAssignment$"),
+            Some(CompilationKind::GoTest)
+        );
+        assert_eq!(
+            kind_of("go test ./internal/robot ./internal/cli -run TestExitCode"),
+            Some(CompilationKind::GoTest)
+        );
+    }
+
+    #[test]
+    fn go_commands_clear_the_confidence_threshold() {
+        // Default confidence_threshold is 0.85; anything at or below it is never
+        // intercepted, which would silently keep these local.
+        for cmd in ["go build ./...", "go test ./...", "go vet ./..."] {
+            let c = classify_command(cmd);
+            assert!(
+                c.confidence > 0.85,
+                "{cmd} scored {} which does not clear the 0.85 threshold",
+                c.confidence
+            );
+        }
+    }
+
+    #[test]
+    fn go_test_is_a_test_command() {
+        // Drives cache affinity, the test-slot bucket, and the test timeout.
+        assert!(CompilationKind::GoTest.is_test_command());
+        assert!(!CompilationKind::GoBuild.is_test_command());
+        assert!(!CompilationKind::GoVet.is_test_command());
+    }
+
+    // --- Go: forms that MUST stay local (would otherwise lose artifacts) ---
+
+    #[test]
+    fn go_build_with_output_flag_is_not_offloaded() {
+        // Go kinds are stream-only (no artifact sync-back). Offloading an
+        // emitting build would report success and leave no binary behind.
+        assert_eq!(kind_of("go build -o bin/app ./cmd/app"), None);
+        assert_eq!(kind_of("go build -o=bin/app ./cmd/app"), None);
+    }
+
+    #[test]
+    fn go_test_c_and_exec_stay_local() {
+        assert_eq!(kind_of("go test -c ./pkg"), None);
+        assert_eq!(kind_of("go test -exec sudo ./pkg"), None);
+    }
+
+    #[test]
+    fn go_state_mutating_subcommands_are_never_intercepted() {
+        for cmd in [
+            "go get github.com/foo/bar",
+            "go mod tidy",
+            "go mod download",
+            "go install ./cmd/tool",
+            "go run main.go",
+            "go generate ./...",
+            "go fmt ./...",
+            "go clean -cache",
+            "go work sync",
+            "go env GOPATH",
+            "go version",
+            "go list ./...",
+            "go tool pprof",
+        ] {
+            assert_eq!(kind_of(cmd), None, "{cmd} must never be intercepted");
+        }
+    }
+
+    #[test]
+    fn go_prefixed_binaries_are_not_matched() {
+        // Keyword matching is whole-word, so these must not be treated as `go`.
+        assert_eq!(kind_of("gofmt -l ."), None);
+        assert_eq!(kind_of("golangci-lint run"), None);
+    }
+
+    // --- TypeScript ---
+
+    #[test]
+    fn tsc_noemit_is_classified() {
+        assert_eq!(kind_of("tsc --noEmit"), Some(CompilationKind::Tsc));
+        assert_eq!(kind_of("npx tsc --noEmit"), Some(CompilationKind::Tsc));
+        // Observed in the wild.
+        assert_eq!(
+            kind_of("npx tsc --noEmit --incremental false"),
+            Some(CompilationKind::Tsc)
+        );
+        // tsc flags are case-insensitive.
+        assert_eq!(kind_of("tsc --noemit"), Some(CompilationKind::Tsc));
+    }
+
+    #[test]
+    fn emitting_tsc_stays_local() {
+        // Without --noEmit, tsc writes .js/.d.ts into the local tree. Tsc is
+        // stream-only, so offloading it would silently produce no output.
+        assert_eq!(kind_of("tsc"), None);
+        assert_eq!(kind_of("tsc -p tsconfig.json"), None);
+        assert_eq!(kind_of("npx tsc --outDir dist"), None);
+    }
+
+    #[test]
+    fn tsc_watch_is_not_intercepted() {
+        assert_eq!(kind_of("tsc --noEmit --watch"), None);
+        assert_eq!(kind_of("tsc --noEmit -w"), None);
+    }
+
+    #[test]
+    fn tsc_trivial_forms_are_not_intercepted() {
+        assert_eq!(kind_of("tsc --version"), None);
+        assert_eq!(kind_of("tsc --init"), None);
+    }
+
+    #[test]
+    fn npx_non_tsc_is_not_intercepted() {
+        // "npx" is a compilation keyword only so `npx tsc` reaches classify_full;
+        // every other npx invocation must fall through.
+        assert_eq!(kind_of("npx jest"), None);
+        assert_eq!(kind_of("npx prettier --write ."), None);
+    }
+
+    // --- command_base drives the execution allowlist ---
+
+    #[test]
+    fn command_base_is_allowlisted() {
+        use crate::types::ExecutionConfig;
+        let exec = ExecutionConfig::default();
+        for kind in [
+            CompilationKind::GoBuild,
+            CompilationKind::GoTest,
+            CompilationKind::GoVet,
+            CompilationKind::Tsc,
+        ] {
+            let base = kind.command_base();
+            assert!(
+                exec.is_allowed(base),
+                "{base} missing from the execution allowlist — the hook would fail \
+                 open to LOCAL execution, silently losing offload"
+            );
+        }
+        assert_eq!(CompilationKind::GoBuild.command_base(), "go");
+        assert_eq!(CompilationKind::Tsc.command_base(), "tsc");
     }
 }

--- a/rch-common/src/proptest_tests.rs
+++ b/rch-common/src/proptest_tests.rs
@@ -661,7 +661,7 @@ mod tests {
                             node_version,
                             npm_version,
                             nix_version: None,
-                go_version: None,
+                            go_version: None,
                             num_cpus,
                             load_avg_1,
                             load_avg_5,

--- a/rch-common/src/proptest_tests.rs
+++ b/rch-common/src/proptest_tests.rs
@@ -604,6 +604,8 @@ mod tests {
                 Just(RequiredRuntime::Rust),
                 Just(RequiredRuntime::Bun),
                 Just(RequiredRuntime::Node),
+                Just(RequiredRuntime::Nix),
+                Just(RequiredRuntime::Go),
             ]
         }
 
@@ -659,6 +661,7 @@ mod tests {
                             node_version,
                             npm_version,
                             nix_version: None,
+                go_version: None,
                             num_cpus,
                             load_avg_1,
                             load_avg_5,

--- a/rch-common/src/types.rs
+++ b/rch-common/src/types.rs
@@ -88,6 +88,8 @@ pub enum RequiredRuntime {
     Node,
     /// Requires the Nix package manager (nix binary + populated `/nix/store`).
     Nix,
+    /// Requires the Go toolchain (`go` binary).
+    Go,
 }
 
 /// Per-command priority hint for worker selection.
@@ -717,6 +719,10 @@ pub struct WorkerCapabilities {
     /// routing to this worker.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub nix_version: Option<String>,
+    /// Go toolchain version (from `go version`). Presence gates `go build`/
+    /// `go test`/`go vet` routing to this worker.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub go_version: Option<String>,
 
     // Health metrics (bd-3eaa)
     /// Number of CPU cores on the worker.
@@ -786,6 +792,11 @@ impl WorkerCapabilities {
     /// Check if this worker has Nix installed (nix binary + `/nix/store`).
     pub fn has_nix(&self) -> bool {
         self.nix_version.is_some()
+    }
+
+    /// Check if this worker has the Go toolchain installed.
+    pub fn has_go(&self) -> bool {
+        self.go_version.is_some()
     }
 
     /// Calculate load per core (1-minute load average / num_cpus).
@@ -2076,6 +2087,9 @@ impl CompilationConfig {
             // closures); give them the generous test-timeout bucket rather than
             // the short build timeout so legitimate builds are not killed early.
             Some(CompilationKind::NixBuild) => self.test_timeout_sec,
+            // Go test suites are long-running like cargo test; give them the
+            // test bucket rather than the short build timeout.
+            Some(CompilationKind::GoTest) => self.test_timeout_sec,
             // Builds, checks, clippy, and unknown use build timeout
             _ => self.build_timeout_sec,
         };
@@ -2283,6 +2297,10 @@ fn default_execution_allowlist() -> Vec<String> {
         "bun".to_string(),
         // Nix (covers both `nix build` and the legacy `nix-build`)
         "nix".to_string(),
+        // Go
+        "go".to_string(),
+        // TypeScript (covers both `tsc` and `npx tsc`; command_base is "tsc")
+        "tsc".to_string(),
     ]
 }
 
@@ -4949,8 +4967,13 @@ retry_max = 2
         // Unknown commands should not be allowed
         assert!(!config.is_allowed("python"));
         assert!(!config.is_allowed("npm"));
-        assert!(!config.is_allowed("go"));
         assert!(!config.is_allowed(""));
+        // `go` and `tsc` ARE allowed now that Go/TypeScript are offload targets.
+        // If they were missing from the allowlist the hook would fail open to
+        // LOCAL execution — classification would look correct while every build
+        // silently ran on the orchestrator.
+        assert!(config.is_allowed("go"));
+        assert!(config.is_allowed("tsc"));
     }
 
     #[test]

--- a/rch-common/src/worker_facts.rs
+++ b/rch-common/src/worker_facts.rs
@@ -95,6 +95,9 @@ pub struct RuntimeFacts {
     /// Nix version (from `nix --version`, gated on a populated `/nix/store`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub nix_version: Option<String>,
+    /// Go toolchain version (from `go version`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub go_version: Option<String>,
 }
 
 /// One filesystem root's capacity (exact, path-scoped).

--- a/rch-common/tests/admission_goldens_e2e.rs
+++ b/rch-common/tests/admission_goldens_e2e.rs
@@ -152,6 +152,9 @@ fn golden_admit_preflight_wasm() {
             "required": {
                 "needs_cargo": true,
                 "needs_bun": false,
+                "needs_nix": false,
+                "needs_go": false,
+                "needs_node": false,
                 "needs_targets": ["wasm32-unknown-unknown"],
                 "needs_toolchains": [],
             },

--- a/rch-common/tests/dependency_closure_planner.rs
+++ b/rch-common/tests/dependency_closure_planner.rs
@@ -60,6 +60,12 @@ fn write_bin_crate(root: &Path, crate_name: &str, deps: &[(&str, &str)]) {
     .expect("write main.rs");
 }
 
+fn write_lib_crate(root: &Path, crate_name: &str, deps: &[(&str, &str)]) {
+    fs::create_dir_all(root.join("src")).expect("create crate src");
+    fs::write(root.join("Cargo.toml"), crate_manifest(crate_name, deps)).expect("write manifest");
+    fs::write(root.join("src/lib.rs"), "pub fn marker() {}\n").expect("write lib.rs");
+}
+
 fn crate_manifest(crate_name: &str, deps: &[(&str, &str)]) -> String {
     let mut dependencies = String::new();
     for (name, path) in deps {
@@ -132,6 +138,184 @@ fn planner_multi_repo_produces_deterministic_dependency_first_order() {
             DependencySyncReason::TransitivePathDependency,
             DependencySyncReason::EntryPoint,
         ]
+    );
+}
+
+#[test]
+fn planner_materializes_inactive_optional_cycle_as_full_sync_roots() {
+    let fixture = TopologyFixture::new("optional-materialization");
+    let scenario_root = fixture.canonical_root.join("optional_materialization");
+    let app_root = scenario_root.join("app");
+    let real_dep_root = scenario_root.join("real_dep");
+    let optional_a_root = scenario_root.join("optional_a");
+    let optional_b_root = scenario_root.join("optional_b");
+
+    write_lib_crate(&real_dep_root, "real_dep", &[]);
+    write_lib_crate(
+        &optional_a_root,
+        "optional_a",
+        &[("optional_b", "../optional_b")],
+    );
+    write_lib_crate(
+        &optional_b_root,
+        "optional_b",
+        &[("optional_a", "../optional_a")],
+    );
+    fs::create_dir_all(app_root.join("src")).expect("create app src");
+    fs::write(
+        app_root.join("Cargo.toml"),
+        r#"[package]
+name = "optional_materialization_app"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+real_dep = { path = "../real_dep" }
+optional_a = { path = "../optional_a", optional = true }
+"#,
+    )
+    .expect("write app manifest");
+    fs::write(app_root.join("src/main.rs"), "fn main() {}\n").expect("write app main");
+
+    let plan = build_dependency_closure_plan_with_policy(&app_root, &fixture.policy());
+
+    assert!(
+        plan.is_ready(),
+        "the optional cycle must not enter the active topological-order calculation"
+    );
+    let expected_roots = [
+        &app_root,
+        &real_dep_root,
+        &optional_a_root,
+        &optional_b_root,
+    ]
+    .into_iter()
+    .map(|root| root.canonicalize().expect("canonical fixture package"))
+    .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(
+        plan.sync_roots()
+            .into_iter()
+            .collect::<std::collections::BTreeSet<_>>(),
+        expected_roots,
+        "all potentially activatable source roots must enter full synchronization"
+    );
+    for package_name in ["optional_a", "optional_b"] {
+        let action = plan
+            .sync_order
+            .iter()
+            .find(|action| action.package_name == package_name)
+            .expect("materialization-only sync action");
+        assert!(
+            action
+                .metadata
+                .notes
+                .iter()
+                .any(|note| note == "materialization_only=true")
+        );
+    }
+}
+
+#[test]
+fn planner_uses_workspace_root_for_inherited_optional_materialization() {
+    let fixture = TopologyFixture::new("workspace-inherited-materialization");
+    let scenario_root = fixture
+        .canonical_root
+        .join("workspace_inherited_materialization");
+    let workspace_root = scenario_root.join("workspace");
+    let app_root = workspace_root.join("crates/app");
+    let optional_dep_root = scenario_root.join("optional_dep");
+
+    write_lib_crate(&optional_dep_root, "workspace_optional_dep", &[]);
+    fs::create_dir_all(app_root.join("src")).expect("create app src");
+    fs::write(
+        app_root.join("Cargo.toml"),
+        r#"[package]
+name = "workspace_inherited_app"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+workspace_optional_dep = { workspace = true, optional = true }
+"#,
+    )
+    .expect("write app manifest");
+    fs::write(app_root.join("src/lib.rs"), "pub fn app() {}\n").expect("write app lib");
+    fs::create_dir_all(&workspace_root).expect("create workspace root");
+    fs::write(
+        workspace_root.join("Cargo.toml"),
+        r#"[workspace]
+members = ["crates/app"]
+resolver = "3"
+
+[workspace.dependencies]
+workspace_optional_dep = { path = "../optional_dep" }
+"#,
+    )
+    .expect("write workspace manifest");
+
+    let plan = build_dependency_closure_plan_with_policy(&app_root, &fixture.policy());
+
+    assert!(plan.is_ready());
+    let app_root = app_root.canonicalize().expect("canonical app");
+    let optional_dep_root = optional_dep_root
+        .canonicalize()
+        .expect("canonical optional dep");
+    assert_eq!(
+        plan.sync_roots()
+            .into_iter()
+            .collect::<std::collections::BTreeSet<_>>(),
+        std::collections::BTreeSet::from([app_root, optional_dep_root.clone()])
+    );
+    let optional_action = plan
+        .sync_order
+        .iter()
+        .find(|action| action.package_root == optional_dep_root)
+        .expect("workspace-inherited optional materialization action");
+    assert!(
+        optional_action
+            .metadata
+            .notes
+            .iter()
+            .any(|note| note == "materialization_only=true")
+    );
+}
+
+#[test]
+fn planner_marks_missing_inactive_path_as_materialization_failure() {
+    let fixture = TopologyFixture::new("missing-optional-materialization");
+    let app_root = fixture
+        .canonical_root
+        .join("missing_optional_materialization/app");
+    fs::create_dir_all(app_root.join("src")).expect("create app src");
+    fs::write(
+        app_root.join("Cargo.toml"),
+        r#"[package]
+name = "missing_optional_materialization_app"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+missing_optional = { path = "../missing_optional", optional = true }
+"#,
+    )
+    .expect("write app manifest");
+    fs::write(app_root.join("src/lib.rs"), "pub fn app() {}\n").expect("write app lib");
+
+    let plan = build_dependency_closure_plan_with_policy(&app_root, &fixture.policy());
+
+    assert_eq!(plan.state, DependencyClosurePlanState::FailOpen);
+    assert!(plan.fail_open);
+    assert!(plan.sync_order.is_empty());
+    assert!(
+        plan.issues
+            .iter()
+            .any(|issue| issue.code == "materialization-closure-unavailable"),
+        "missing inactive paths must be distinguished from ordinary active graph fallback"
+    );
+    assert!(
+        plan.fail_open_reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("materialization closure produced"))
     );
 }
 

--- a/rch-wkr/src/executor.rs
+++ b/rch-wkr/src/executor.rs
@@ -462,14 +462,30 @@ pub async fn execute(workdir: &str, command: &str) -> Result<()> {
 
     // Use shell execution to properly handle quoted arguments and shell features
     // This matches how the SSH client executes commands (sh -c "...")
-    let mut child = Command::new("sh")
-        .arg("-c")
+    let mut cmd = Command::new("sh");
+    cmd.arg("-c")
         .arg(command)
         .current_dir(workdir)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .kill_on_drop(true)
-        .spawn()?;
+        .kill_on_drop(true);
+
+    // For Node/Bun projects, put the project's own `node_modules/.bin` FIRST on
+    // PATH. Workers have no global `tsc`, so a bare `tsc --noEmit` would
+    // otherwise fail to resolve — and if we papered over that with a global
+    // install, a project pinned to an older TypeScript would be typechecked by a
+    // newer compiler and could report errors the user never sees locally.
+    // Resolving the project's own binary keeps remote results identical to local.
+    // `prepare()` (above) has already installed node_modules by this point.
+    if matches!(runtime, RequiredRuntime::Bun | RequiredRuntime::Node) {
+        let local_bin = Path::new(workdir).join("node_modules").join(".bin");
+        if local_bin.is_dir() {
+            let existing = std::env::var("PATH").unwrap_or_default();
+            cmd.env("PATH", format!("{}:{existing}", local_bin.display()));
+        }
+    }
+
+    let mut child = cmd.spawn()?;
 
     // Stream stdout
     let mut stdout = child.stdout.take().expect("Failed to capture stdout");

--- a/rch-wkr/src/executor.rs
+++ b/rch-wkr/src/executor.rs
@@ -139,9 +139,21 @@ fn detect_runtime_from_command(command: &str) -> RequiredRuntime {
                 return RequiredRuntime::Node;
             }
         }
-        Some("npx") if matches!(tokens.next(), Some("jest" | "vitest")) => {
-            return RequiredRuntime::Node;
-        }
+        Some("npx") => match tokens.next() {
+            Some("jest" | "vitest") => return RequiredRuntime::Node,
+            // `npx tsc --noEmit` needs node_modules installed before it can
+            // resolve types, so it must report the Node runtime to get prepare().
+            Some("tsc") => return RequiredRuntime::Node,
+            _ => {}
+        },
+        // Bare `tsc` likewise runs under Node and needs node_modules.
+        Some("tsc") => return RequiredRuntime::Node,
+        // Go resolves modules from the module cache; prepare() is a no-op for it,
+        // but the runtime must still be reported so the right prepare branch runs.
+        Some("go") => match tokens.next() {
+            Some("build" | "test" | "vet") => return RequiredRuntime::Go,
+            _ => {}
+        },
         _ => {}
     }
     RequiredRuntime::None

--- a/rch-wkr/src/main.rs
+++ b/rch-wkr/src/main.rs
@@ -444,6 +444,17 @@ fn probe_capabilities() -> WorkerCapabilities {
         }
     }
 
+    // Probe Go toolchain. Presence gates `go build`/`go test`/`go vet` routing to
+    // this worker via `has_go()`.
+    if let Ok(output) = Command::new("go").args(["version"]).output()
+        && output.status.success()
+    {
+        let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !version.is_empty() {
+            capabilities.go_version = Some(version);
+        }
+    }
+
     // Probe system health metrics (bd-3eaa)
     capabilities.num_cpus = probe_num_cpus();
     if let Some((load1, load5, load15)) = probe_load_average() {

--- a/rch-wkr/src/prepare.rs
+++ b/rch-wkr/src/prepare.rs
@@ -371,7 +371,12 @@ pub async fn prepare(
         }
         // Nix fetches its own inputs into /nix/store at build time and needs no
         // node_modules-style prepare step, so it is skipped like Rust/None.
-        RequiredRuntime::Rust | RequiredRuntime::None | RequiredRuntime::Nix => Ok(PrepareReport {
+        // Go resolves its own modules from the module cache at build time and
+        // needs no node_modules-style prepare step, so it is skipped like Rust/Nix.
+        RequiredRuntime::Rust
+        | RequiredRuntime::None
+        | RequiredRuntime::Nix
+        | RequiredRuntime::Go => Ok(PrepareReport {
             runtime,
             action: PrepareAction::Skipped,
             fingerprint: None,

--- a/rch/src/commands/helpers.rs
+++ b/rch/src/commands/helpers.rs
@@ -129,6 +129,7 @@ pub fn runtime_label(runtime: &RequiredRuntime) -> &'static str {
         RequiredRuntime::Bun => "bun",
         RequiredRuntime::Node => "node",
         RequiredRuntime::Nix => "nix",
+        RequiredRuntime::Go => "go",
         RequiredRuntime::None => "none",
     }
 }

--- a/rch/src/commands/status.rs
+++ b/rch/src/commands/status.rs
@@ -515,6 +515,7 @@ pub async fn diagnose(command: &str, dry_run: bool, ctx: &OutputContext) -> Resu
                                     RequiredRuntime::Bun => !caps.has_bun(),
                                     RequiredRuntime::Node => !caps.has_node(),
                                     RequiredRuntime::Nix => !caps.has_nix(),
+                                    RequiredRuntime::Go => !caps.has_go(),
                                     RequiredRuntime::None => false,
                                 }
                             })

--- a/rch/src/commands/workers.rs
+++ b/rch/src/commands/workers.rs
@@ -602,6 +602,7 @@ pub async fn workers_capabilities(
                     RequiredRuntime::Bun => !caps.has_bun(),
                     RequiredRuntime::Node => !caps.has_node(),
                     RequiredRuntime::Nix => !caps.has_nix(),
+                    RequiredRuntime::Go => !caps.has_go(),
                     RequiredRuntime::None => false,
                 }
             })

--- a/rch/src/hook.rs
+++ b/rch/src/hook.rs
@@ -1103,8 +1103,9 @@ mod ssh;
 // sync-closure planners + verifier directly from `super::dependency_closure`.
 mod dependency_closure;
 use dependency_closure::{
-    DEPENDENCY_PREFLIGHT_CODE_POLICY, DEPENDENCY_PREFLIGHT_CODE_TIMEOUT,
-    DEPENDENCY_PREFLIGHT_CODE_UNKNOWN, DEPENDENCY_PREFLIGHT_REMEDIATION_POLICY,
+    DEPENDENCY_PREFLIGHT_CODE_MATERIALIZATION, DEPENDENCY_PREFLIGHT_CODE_POLICY,
+    DEPENDENCY_PREFLIGHT_CODE_TIMEOUT, DEPENDENCY_PREFLIGHT_CODE_UNKNOWN,
+    DEPENDENCY_PREFLIGHT_REMEDIATION_MATERIALIZATION, DEPENDENCY_PREFLIGHT_REMEDIATION_POLICY,
     DEPENDENCY_PREFLIGHT_REMEDIATION_TIMEOUT, DEPENDENCY_PREFLIGHT_REMEDIATION_UNKNOWN,
     DEPENDENCY_PREFLIGHT_SCHEMA_VERSION, DependencyPreflightEvidence, DependencyPreflightFailure,
     DependencyPreflightReport, DependencyPreflightStatus,
@@ -1771,6 +1772,10 @@ fn classify_dependency_runtime_fail_open(
         .issues
         .iter()
         .any(|issue| issue.code == "path-policy-violation");
+    let has_materialization_failure = plan
+        .issues
+        .iter()
+        .any(|issue| issue.code == "materialization-closure-unavailable");
     let has_timeout = plan
         .fail_open_reason
         .as_deref()
@@ -1787,6 +1792,11 @@ fn classify_dependency_runtime_fail_open(
         (
             DEPENDENCY_PREFLIGHT_CODE_POLICY,
             DEPENDENCY_PREFLIGHT_REMEDIATION_POLICY,
+        )
+    } else if has_materialization_failure {
+        (
+            DEPENDENCY_PREFLIGHT_CODE_MATERIALIZATION,
+            DEPENDENCY_PREFLIGHT_REMEDIATION_MATERIALIZATION,
         )
     } else if has_timeout {
         (
@@ -1829,6 +1839,8 @@ fn build_dependency_runtime_fail_open_report(
 ) -> DependencyPreflightReport {
     let status = if decision.reason_code == DEPENDENCY_PREFLIGHT_CODE_POLICY {
         DependencyPreflightStatus::PolicyViolation
+    } else if decision.reason_code == DEPENDENCY_PREFLIGHT_CODE_MATERIALIZATION {
+        DependencyPreflightStatus::MaterializationUnavailable
     } else if decision.reason_code == DEPENDENCY_PREFLIGHT_CODE_TIMEOUT {
         DependencyPreflightStatus::Timeout
     } else {
@@ -1862,6 +1874,7 @@ fn build_dependency_runtime_fail_open_report(
 
 fn should_force_local_fallback_for_runtime_fail_open(reason_code: &str) -> bool {
     reason_code == DEPENDENCY_PREFLIGHT_CODE_POLICY
+        || reason_code == DEPENDENCY_PREFLIGHT_CODE_MATERIALIZATION
 }
 
 fn command_uses_cargo_dependency_graph(kind: Option<CompilationKind>) -> bool {

--- a/rch/src/hook.rs
+++ b/rch/src/hook.rs
@@ -1969,6 +1969,17 @@ pub(crate) fn required_runtime_for_kind(kind: Option<CompilationKind>) -> Requir
 
             CompilationKind::NixBuild => RequiredRuntime::Nix,
 
+            // Go builds/tests/vets must carry the Go runtime so worker selection
+            // gates them to a go-capable worker via `has_go()`. Falling through to
+            // the `_ => None` catch-all would disable capability gating entirely and
+            // dispatch `go build` to a worker with no Go toolchain.
+            CompilationKind::GoBuild | CompilationKind::GoTest | CompilationKind::GoVet => {
+                RequiredRuntime::Go
+            }
+
+            // `tsc` / `npx tsc` run under Node.
+            CompilationKind::Tsc => RequiredRuntime::Node,
+
             _ => RequiredRuntime::None,
         },
         None => RequiredRuntime::None,

--- a/rch/src/hook.rs
+++ b/rch/src/hook.rs
@@ -727,10 +727,26 @@ pub async fn run_exec(command_parts: Vec<String>) -> anyhow::Result<()> {
     let estimated_cores =
         estimate_cores_for_command(classification.kind, &command, &config.compilation);
 
-    // Detect toolchain
+    // Detect toolchain — ONLY for Rust kinds.
+    //
+    // `detect_toolchain` returns the ambient rustup toolchain (e.g. from
+    // rust-toolchain.toml, or the active default). Attaching it to a NON-Rust
+    // request is actively harmful: rchd runs a per-worker toolchain preflight, and
+    // a worker that does not happen to have that exact nightly installed fails it
+    // and is excluded as a HARD preflight failure. With every worker excluded the
+    // build falls back to LOCAL — so a `go build` on a box whose rustup default is
+    // `nightly-2026-07-11` would silently keep running on the orchestrator, which
+    // is precisely the bug this feature exists to fix. Go/TS/Bun/Nix builds need no
+    // rustup toolchain, so send none.
     let project_root = std::env::current_dir().ok();
-    let toolchain = if let Some(root) = &project_root {
-        detect_toolchain(root).ok()
+    let needs_rust_toolchain = matches!(
+        required_runtime_for_kind(classification.kind),
+        RequiredRuntime::Rust
+    );
+    let toolchain = if needs_rust_toolchain {
+        project_root
+            .as_ref()
+            .and_then(|root| detect_toolchain(root).ok())
     } else {
         None
     };

--- a/rch/src/hook/artifact_patterns.rs
+++ b/rch/src/hook/artifact_patterns.rs
@@ -59,6 +59,17 @@ pub(super) fn get_artifact_patterns(kind: Option<CompilationKind>) -> Vec<String
         // symlink that is meaningless on a nix-less local host, so nothing is
         // synced back — the exit status is the payload (streaming only).
         Some(CompilationKind::NixBuild) => Vec::new(),
+        // Go and TypeScript kinds are stream-only by construction: the classifier
+        // only accepts the non-emitting forms (`go build` without `-o`, `go test`,
+        // `go vet`, `tsc --noEmit`), so there is no output file to bring home and
+        // the exit status is the payload. Emitting forms are declined in
+        // classify_go/classify_tsc and run locally. Falling through to the
+        // `_ => default_rust_artifact_patterns()` catch-all would sync back
+        // `target/**` — the wrong tree entirely.
+        Some(CompilationKind::GoBuild)
+        | Some(CompilationKind::GoTest)
+        | Some(CompilationKind::GoVet)
+        | Some(CompilationKind::Tsc) => Vec::new(),
         _ => default_rust_artifact_patterns(),
     }
 }
@@ -161,7 +172,13 @@ pub(super) fn kind_produces_transferable_artifacts(kind: Option<CompilationKind>
         | Some(CompilationKind::BunTest)
         | Some(CompilationKind::BunTypecheck)
         // Nix builds stream their result; outputs stay in the worker's /nix/store.
-        | Some(CompilationKind::NixBuild) => false,
+        | Some(CompilationKind::NixBuild)
+        // Go/TS: only non-emitting forms are ever offloaded (see classify_go /
+        // classify_tsc), so there is no required local artifact.
+        | Some(CompilationKind::GoBuild)
+        | Some(CompilationKind::GoTest)
+        | Some(CompilationKind::GoVet)
+        | Some(CompilationKind::Tsc) => false,
         // Unclassified command: be conservative and treat a sync-back failure as
         // benign (we cannot prove a required artifact exists), matching the legacy
         // continue-on-warning behavior.

--- a/rch/src/hook/command_parsing.rs
+++ b/rch/src/hook/command_parsing.rs
@@ -285,10 +285,16 @@ pub(crate) fn estimate_cores_for_command(
         Some(
             CompilationKind::CargoCheck
             | CompilationKind::CargoClippy
-            | CompilationKind::BunTypecheck,
+            | CompilationKind::BunTypecheck
+            // `go vet` and `tsc --noEmit` are diagnostic passes, not builds.
+            | CompilationKind::GoVet
+            | CompilationKind::Tsc,
         ) => cargo_job_count_for_command(command)
             .unwrap_or(check_default)
             .max(1),
+        // Go: `-j/--jobs` is meaningless (go uses `-p`), so don't try to parse a
+        // cargo job count out of the command — take the default bucket directly.
+        Some(CompilationKind::GoBuild) => build_default.max(1),
         Some(_) => cargo_job_count_for_command(command)
             .unwrap_or(build_default)
             .max(1),

--- a/rch/src/hook/dependency_closure.rs
+++ b/rch/src/hook/dependency_closure.rs
@@ -107,12 +107,14 @@ pub(super) const DEPENDENCY_PREFLIGHT_CODE_STALE: &str = "RCH-E411";
 pub(super) const DEPENDENCY_PREFLIGHT_CODE_UNKNOWN: &str = "RCH-E412";
 pub(super) const DEPENDENCY_PREFLIGHT_CODE_POLICY: &str = "RCH-E413";
 pub(super) const DEPENDENCY_PREFLIGHT_CODE_TIMEOUT: &str = "RCH-E414";
+pub(super) const DEPENDENCY_PREFLIGHT_CODE_MATERIALIZATION: &str = "RCH-E415";
 pub(super) const DEPENDENCY_PREFLIGHT_REMEDIATION_MISSING: &str = "Ensure every dependency root in the closure is synced and Cargo.toml plus required source entrypoints exist remotely.";
 pub(super) const DEPENDENCY_PREFLIGHT_REMEDIATION_STALE: &str = "One or more dependency roots were not refreshed; rerun after successful sync of skipped roots.";
 pub(super) const DEPENDENCY_PREFLIGHT_REMEDIATION_UNKNOWN: &str =
     "Dependency verification could not determine remote state; inspect sync/SSH logs and retry.";
 pub(super) const DEPENDENCY_PREFLIGHT_REMEDIATION_POLICY: &str = "Path dependency topology policy failed; move dependencies under /data/projects (or /dp) and retry.";
 pub(super) const DEPENDENCY_PREFLIGHT_REMEDIATION_TIMEOUT: &str = "Dependency planner timed out; rerun after system load decreases or investigate cargo metadata latency.";
+pub(super) const DEPENDENCY_PREFLIGHT_REMEDIATION_MATERIALIZATION: &str = "Cargo path materialization is incomplete; repair the reported repository manifest/path dependency before retrying remote Cargo execution.";
 pub(super) const DEPENDENCY_PREFLIGHT_PROBE_BATCH_SIZE: usize = 128;
 const WORKSPACE_METADATA_SYNC_PATTERNS: &[&str] = &[
     "Cargo.toml",
@@ -131,6 +133,7 @@ pub(super) enum DependencyPreflightStatus {
     Stale,
     PolicyViolation,
     Timeout,
+    MaterializationUnavailable,
     Unknown,
 }
 
@@ -200,6 +203,7 @@ fn dependency_preflight_status_label(status: DependencyPreflightStatus) -> &'sta
         DependencyPreflightStatus::Stale => "stale",
         DependencyPreflightStatus::PolicyViolation => "policy_violation",
         DependencyPreflightStatus::Timeout => "timeout",
+        DependencyPreflightStatus::MaterializationUnavailable => "materialization_unavailable",
         DependencyPreflightStatus::Unknown => "unknown",
     }
 }
@@ -265,6 +269,15 @@ fn dependency_preflight_failure_reason(
         return Some((
             DEPENDENCY_PREFLIGHT_CODE_STALE,
             DEPENDENCY_PREFLIGHT_REMEDIATION_STALE,
+        ));
+    }
+    if evidence
+        .iter()
+        .any(|item| item.status == DependencyPreflightStatus::MaterializationUnavailable)
+    {
+        return Some((
+            DEPENDENCY_PREFLIGHT_CODE_MATERIALIZATION,
+            DEPENDENCY_PREFLIGHT_REMEDIATION_MATERIALIZATION,
         ));
     }
     if evidence

--- a/rch/src/hook/tests.rs
+++ b/rch/src/hook/tests.rs
@@ -3579,6 +3579,30 @@ fn test_classify_dependency_runtime_fail_open_policy_violation() {
 }
 
 #[test]
+fn test_classify_dependency_runtime_fail_open_materialization_failure() {
+    let _guard = test_guard!();
+    let plan = make_fail_open_plan(
+        Some("materialization closure produced missing path dependency"),
+        vec![rch_common::DependencyPlanIssue {
+            code: "materialization-closure-unavailable".to_string(),
+            message: "inactive optional path dependency is missing".to_string(),
+            risk: rch_common::DependencyRiskClass::Critical,
+            diagnostics: vec!["dependency_name=optional_dep".to_string()],
+        }],
+    );
+
+    let decision = classify_dependency_runtime_fail_open(&plan);
+    assert_eq!(
+        decision.reason_code,
+        DEPENDENCY_PREFLIGHT_CODE_MATERIALIZATION
+    );
+    assert_eq!(
+        decision.remediation,
+        DEPENDENCY_PREFLIGHT_REMEDIATION_MATERIALIZATION
+    );
+}
+
+#[test]
 fn test_classify_dependency_runtime_fail_open_timeout_signal() {
     let _guard = test_guard!();
     let plan = make_fail_open_plan(
@@ -3646,10 +3670,36 @@ fn test_build_dependency_runtime_fail_open_report_uses_status_mapping() {
 }
 
 #[test]
-fn test_should_force_local_fallback_for_runtime_fail_open_policy_only() {
+fn test_build_dependency_runtime_fail_open_report_maps_materialization_failure() {
+    let _guard = test_guard!();
+    let worker = make_test_worker_config("worker-runtime-materialization");
+    let project_root = PathBuf::from("/data/projects/runtime-materialization");
+    let decision = DependencyRuntimeFailOpenDecision {
+        reason_code: DEPENDENCY_PREFLIGHT_CODE_MATERIALIZATION,
+        remediation: DEPENDENCY_PREFLIGHT_REMEDIATION_MATERIALIZATION,
+        detail: "optional path root unavailable".to_string(),
+    };
+
+    let report = build_dependency_runtime_fail_open_report(&worker, &project_root, &decision);
+    assert!(!report.verified);
+    assert_eq!(
+        report.reason_code,
+        Some(DEPENDENCY_PREFLIGHT_CODE_MATERIALIZATION)
+    );
+    assert_eq!(
+        report.evidence[0].status,
+        DependencyPreflightStatus::MaterializationUnavailable
+    );
+}
+
+#[test]
+fn test_should_force_local_fallback_for_unsafe_runtime_fail_open() {
     let _guard = test_guard!();
     assert!(should_force_local_fallback_for_runtime_fail_open(
         DEPENDENCY_PREFLIGHT_CODE_POLICY
+    ));
+    assert!(should_force_local_fallback_for_runtime_fail_open(
+        DEPENDENCY_PREFLIGHT_CODE_MATERIALIZATION
     ));
     assert!(!should_force_local_fallback_for_runtime_fail_open(
         DEPENDENCY_PREFLIGHT_CODE_UNKNOWN

--- a/rch/src/hook_windows.rs
+++ b/rch/src/hook_windows.rs
@@ -100,6 +100,17 @@ pub(crate) fn required_runtime_for_kind(kind: Option<CompilationKind>) -> Requir
             // non-nix worker (where it would fail) instead of being gated.
             CompilationKind::NixBuild => RequiredRuntime::Nix,
 
+            // Go builds/tests/vets must carry the Go runtime so worker selection
+            // gates them to a go-capable worker via `has_go()`. Falling through to
+            // the `_ => None` catch-all would disable capability gating entirely and
+            // dispatch `go build` to a worker with no Go toolchain.
+            CompilationKind::GoBuild | CompilationKind::GoTest | CompilationKind::GoVet => {
+                RequiredRuntime::Go
+            }
+
+            // `tsc` / `npx tsc` run under Node.
+            CompilationKind::Tsc => RequiredRuntime::Node,
+
             _ => RequiredRuntime::None,
         },
         None => RequiredRuntime::None,

--- a/rch/src/transfer.rs
+++ b/rch/src/transfer.rs
@@ -1288,6 +1288,10 @@ fi",
             Some(CompilationKind::Ninja) => "ninja",
             Some(CompilationKind::Meson) => "meson",
             Some(CompilationKind::NixBuild) => "nix build",
+            Some(CompilationKind::GoBuild) => "go build",
+            Some(CompilationKind::GoTest) => "go test",
+            Some(CompilationKind::GoVet) => "go vet",
+            Some(CompilationKind::Tsc) => "tsc",
             None => "unknown",
         };
 

--- a/rch/src/transfer.rs
+++ b/rch/src/transfer.rs
@@ -1237,9 +1237,49 @@ fi",
         };
 
         format!(
-            "export LC_ALL=C; touch {} && cd {} && {}{}",
-            escaped_remote_path, escaped_remote_path, ensure_dirs_command, execution_command
+            "export LC_ALL=C; touch {} && cd {} && {}{}{}",
+            escaped_remote_path,
+            escaped_remote_path,
+            self.node_modules_bootstrap(),
+            ensure_dirs_command,
+            execution_command
         )
+    }
+
+    /// Provision `node_modules` on the worker for TypeScript kinds.
+    ///
+    /// The project sync deliberately EXCLUDES `node_modules/` (see
+    /// `default_excludes`), and that exclusion is correct: node_modules holds
+    /// platform-native binaries, so rsyncing a macOS tree onto a Linux worker
+    /// would ship unusable `.node` files. rch-wkr has a `prepare()` hook that
+    /// installs dependencies — but the hook's build path executes the command
+    /// over plain SSH and never invokes `rch-wkr execute`, so on this path
+    /// nothing provisions them.
+    ///
+    /// Without this, `tsc --noEmit` on a worker finds no project-local
+    /// TypeScript, and `npx` silently downloads the unrelated `tsc` stub package
+    /// from the registry — which prints "This is not the tsc command you are
+    /// looking for" and exits 1, turning a passing local typecheck into a failing
+    /// remote build.
+    ///
+    /// Install only when `node_modules` is absent. The worker's project directory
+    /// persists between builds, so this is a one-time cost per project. `npm ci`
+    /// is preferred (lockfile-exact, so the worker typechecks with the SAME
+    /// TypeScript version as local); `npm install` is the fallback for projects
+    /// with no lockfile. Installer output is routed to stderr so it can never
+    /// pollute the command's stdout.
+    ///
+    /// Deliberately scoped to `Tsc` only: Bun kinds keep their existing behavior.
+    fn node_modules_bootstrap(&self) -> &'static str {
+        match self.compilation_kind {
+            Some(CompilationKind::Tsc) => {
+                "if [ -f package.json ] && [ ! -d node_modules ]; then \
+                 (npm ci --no-audit --no-fund --loglevel=error || \
+                  npm install --no-audit --no-fund --loglevel=error) 1>&2 || exit 1; \
+                 fi && "
+            }
+            _ => "",
+        }
     }
 
     /// Wrap a command with an external timeout to prevent zombie/stuck processes.

--- a/rchd/src/selection.rs
+++ b/rchd/src/selection.rs
@@ -1310,6 +1310,7 @@ impl WorkerSelector {
                 RequiredRuntime::Bun => capabilities.has_bun(),
                 RequiredRuntime::Node => capabilities.has_node(),
                 RequiredRuntime::Nix => capabilities.has_nix(),
+                RequiredRuntime::Go => capabilities.has_go(),
             };
 
             let toolchain_mismatch =
@@ -1724,6 +1725,7 @@ impl WorkerSelector {
                 RequiredRuntime::Bun => worker.has_bun().await,
                 RequiredRuntime::Node => worker.has_node().await,
                 RequiredRuntime::Nix => worker.has_nix().await,
+                RequiredRuntime::Go => worker.has_go().await,
             };
 
             if excluded_worker_ids.contains(worker_id.as_str()) {
@@ -2708,6 +2710,7 @@ pub async fn select_worker_with_config(
             RequiredRuntime::Bun => worker.has_bun().await,
             RequiredRuntime::Node => worker.has_node().await,
             RequiredRuntime::Nix => worker.has_nix().await,
+            RequiredRuntime::Go => worker.has_go().await,
         };
 
         if !has_required_runtime {

--- a/rchd/src/workers.rs
+++ b/rchd/src/workers.rs
@@ -901,6 +901,11 @@ impl WorkerState {
         self.capabilities.read().await.has_nix()
     }
 
+    /// Whether this worker has the Go toolchain installed.
+    pub async fn has_go(&self) -> bool {
+        self.capabilities.read().await.has_go()
+    }
+
     /// Disable the worker with an optional reason.
     /// Sets status to Disabled and records the timestamp and reason.
     pub async fn disable(&self, reason: Option<String>) {


### PR DESCRIPTION
## Summary

Adds Go and TypeScript offload to rch. Before this, `go build/test/vet` and `tsc` were never classified as compilation, so every one of them ran **locally on the orchestrator** while rust-only worker slots sat idle. On a 128-core box running a 32-agent swarm this drove load to 101/128 with 31.6% system time and 51 idle remote slots.

New `CompilationKind`s, all **stream-only** (no artifact transfer):

- `GoBuild` — `go build ./...`; declines `-o` / `-c` / `-exec` (those produce local outputs)
- `GoTest` — `go test ./...` (uses the test timeout bucket)
- `GoVet` — `go vet ./...`
- `Tsc` — requires `--noEmit`; declines `--watch`. Emitting runs stay local.

No toolchain installation was needed anywhere — every worker already had Go and Node. rch simply never probed for them or classified their commands.

## The three non-obvious fixes

**1. `default_execution_allowlist()` must list the new binaries.** Without `"go"` / `"tsc"` there, classification looks correct but the hook fails **open to local execution**. The new tests assert `command_base()` is in the allowlist for every new kind, so this can't silently regress.

**2. `detect_toolchain()` was running unconditionally**, attaching a rustup toolchain to Go builds. Every worker then failed hard preflight (`toolchain 'nightly-…' is not installed`) and the whole thing fell back to local. It's now gated to `RequiredRuntime::Rust`. This was latent for Bun/Nix too.

**3. The hook executes remote commands over plain SSH** (`build_remote_command` → `cd <path> && <cmd>`), *not* via `rch-wkr execute` — so `rch-wkr`'s `prepare()` never runs on the build path. Since the sync correctly excludes `node_modules/` (it holds platform-native binaries), `tsc` had no compiler on the worker. Added a `node_modules_bootstrap()` that runs `npm ci || npm install` on the worker when `package.json` exists and `node_modules` doesn't.

Note that worker `tags` in `workers.toml` are decorative — routing is gated exclusively by `RequiredRuntime` → `WorkerCapabilities::has_*()`, so this adds `has_go()` and wires it into all three gate sites in `rchd/src/selection.rs`.

## Test plan

- 13 new unit tests in `rch-common/src/patterns.rs` covering both the intercept and the decline paths for each new kind, plus allowlist assertions. Two pre-existing tests encoded the old "go is never compilation" behavior and were updated deliberately.
- Verified end-to-end across the fleet (18 hosts on 1.0.48):
  - `go build ./...` → `[RCH] remote ovh-a (36.4s)`
  - `go vet ./...` → `[RCH] remote vmi1153651 (97.7s)` (from an arm64 mac to an x86_64 worker; safe because these kinds are stream-only)
  - `go test ./...` → remote, with genuine Go test output and a faithful failing exit code
  - `tsc --noEmit` → remote; local and remote agree exactly on both exit code and diagnostics
- Confirmed the worker's git tree stays clean — nothing is written back into source.

## One behavior worth knowing

`tsc` exiting **2** is correct, not a bug: that's TypeScript's `DiagnosticsPresent_OutputsGenerated`. rch propagates the remote exit code verbatim, and running the same command by hand on a worker also gives 2. Diagnostics arrive on **stderr**, because the hook's stdout is the PreToolUse JSON protocol channel and can't be polluted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
